### PR TITLE
Small changes to HtmlMouse to simplify interface.

### DIFF
--- a/dart/lib/html.dart
+++ b/dart/lib/html.dart
@@ -83,29 +83,36 @@ class _HtmlMouse implements PageLoaderMouse {
 
   final HtmlPageLoader loader;
 
+  _ElementPageLoaderElement _eventTarget;
   int clientX = 0;
   int clientY = 0;
 
   _HtmlMouse(this.loader);
 
   @override
-  void down(int button, {_ElementPageLoaderElement eventTarget}) {
-    dispatchEvent('mousedown', eventTarget, button);
+  void down(int button) {
+    if (_eventTarget == null) {
+      throw new StateError('Use moveTo before sending a mouse button event.');
+    }
+    dispatchEvent('mousedown', _eventTarget, button);
     loader.sync();
   }
 
   @override
-  void moveTo(_ElementPageLoaderElement element, int xOffset, int yOffset,
-      {_ElementPageLoaderElement eventTarget}) {
+  void moveTo(_ElementPageLoaderElement element, int xOffset, int yOffset) {
     clientX = (element.node.getBoundingClientRect().left + xOffset).ceil();
     clientY = (element.node.getBoundingClientRect().top + yOffset).ceil();
-    dispatchEvent('mousemove', eventTarget);
+    _eventTarget = element;
+    dispatchEvent('mousemove', _eventTarget);
     loader.sync();
   }
 
   @override
-  void up(int button, {_ElementPageLoaderElement eventTarget}) {
-    dispatchEvent('mouseup', eventTarget);
+  void up(int button) {
+    if (_eventTarget == null) {
+      throw new StateError('Use moveTo before sending a mouse button event.');
+    }
+    dispatchEvent('mouseup', _eventTarget);
     loader.sync();
   }
 


### PR DESCRIPTION
One problem with having _HtmlMouse have a special interface (not conform to PageLoaderMouse) is static-type checking in Dart code/analysis.

An option to solve this problem while keeping the special functionality would be to store the last _ElementPageLoaderElement as the _eventTarget, and use it for down() and up().

This would be an API breaking change, but I can't seem to find too many examples of people using eventTarget:.