### PR TITLE
Add eventTarget to up and down methods on PageLoaderMouse.

### DIFF
--- a/dart/lib/src/interfaces.dart
+++ b/dart/lib/src/interfaces.dart
@@ -39,11 +39,17 @@ abstract class PageLoader {
 }
 
 abstract class PageLoaderMouse {
-  /// Press [button] on the mouse at its current location.
-  void down(int button);
+  /// Press [button] on the mouse at its current location. If [eventTarget} is
+  /// specified, PageLoader will attempt to fire the corresponding mouse events
+  /// on that target, otherwise it will fire the events on the target that is
+  /// under the current mouse location.
+  void down(int button, {PageLoaderElement eventTarget});
 
-  /// Release [button] on the mouse at its current location.
-  void up(int button);
+  /// Release [button] on the mouse at its current location. If [eventTarget} is
+  /// specified, PageLoader will attempt to fire the corresponding mouse events
+  /// on that target, otherwise it will fire the events on the target that is
+  /// under the current mouse location.
+  void up(int button, {PageLoaderElement eventTarget});
 
   /// Move the mouse to a location relative to [element].
   void moveTo(PageLoaderElement element, int xOffset, int yOffset);

--- a/dart/lib/webdriver.dart
+++ b/dart/lib/webdriver.dart
@@ -65,8 +65,12 @@ class _WebDriverMouse implements PageLoaderMouse {
   _WebDriverMouse(this.driver);
 
   @override
-  void down(int button) {
-    driver.mouse.down(button);
+  void down(int button, {_WebElementPageLoaderElement eventTarget}) {
+    if (eventTarget == null) {
+      driver.mouse.down(button);
+    } else {
+      _fireEvent(eventTarget, 'mousedown', button);
+    }
   }
 
   @override
@@ -78,8 +82,19 @@ class _WebDriverMouse implements PageLoaderMouse {
   }
 
   @override
-  void up(int button) {
-    driver.mouse.up(button);
+  void up(int button, {_WebElementPageLoaderElement eventTarget}) {
+    if (eventTarget == null) {
+      driver.mouse.up(button);
+    } else {
+      _fireEvent(eventTarget, 'mousedown', button);
+    }
+  }
+
+  void _fireEvent(_WebElementPageLoaderElement eventTarget, String type,
+      int button) {
+    driver.execute(
+        "arguments[0].dispatchEvent(new MouseEvent(arguments[1], {'button' : arguments[2]}));",
+        [eventTarget.context, type, button]);
   }
 }
 
@@ -157,8 +172,8 @@ class _WebElementPageLoaderElement extends WebDriverPageLoaderElement {
   String get name => context.name;
 
   @override
-  String get innerText => context.driver.execute(
-      'return arguments[0].textContent;', [context]).trim();
+  String get innerText =>
+      context.driver.execute('return arguments[0].textContent;', [context]).trim();
 
   @override
   String get visibleText => context.text;

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,13 +1,13 @@
 name: pageloader
-version: 1.2.3
+version: 1.2.4
 author: Marc Fisher II
 description: Supports the creation of page objects that can be shared between in-browser tests and WebDriver tests.
 environment:
-  sdk: '>=1.8.0-dev.0.0 <2.0.0'
+  sdk: '>=1.9.0-dev.2.2 <2.0.0'
 dependencies:
   sync_webdriver:
     path: ../../dart-sync-webdriver
 dev_dependencies:
-  browser: '>=0.10.0+2 <0.11.0'
-  path: '>=1.3.0 <2.0.0'
-  unittest: '>=0.11.3 <0.12.0'
+  browser: '^0.10.0+2'
+  path: '^1.3.1'
+  unittest: '^0.11.4'

--- a/dart/test/pageloader_test.dart
+++ b/dart/test/pageloader_test.dart
@@ -327,6 +327,19 @@ void runTests() {
           ..up(0);
       expect(page.element.visibleText, contains('MouseUp'));
     });
+
+    test('mouse with event target', () {
+      PageForMouseTest page = loader.getInstance(PageForMouseTest);
+
+      // make sure mouse is not on element;
+      loader.mouse.moveTo(page.element, -10, -10);
+      loader.mouse.down(0, eventTarget: page.element);
+      expect(page.element.visibleText, contains('MouseDown'));
+      loader.mouse
+          ..moveTo(page.element, 200, 200)
+          ..up(0, eventTarget: page.element);
+      expect(page.element.visibleText, contains('MouseUp'));
+    });
   });
 
   group('waitFor()', () {


### PR DESCRIPTION
Implement support for using eventTarget in WebDriverPageLoader (was
previously supported in HtmlPageLoader).