### PR TITLE
Add option to functions that sync to allow syncing to be disabled.

### DIFF
--- a/dart/lib/sync/html.dart
+++ b/dart/lib/sync/html.dart
@@ -72,7 +72,11 @@ class HtmlPageLoader extends BasePageLoader {
     return getInstanceInternal(type, context);
   }
 
-  void sync() => clock.sleep(_DEFAULT_INTERVAL);
+  void sync([bool enableSync = true]) {
+    if (enableSync) {
+      clock.sleep(_DEFAULT_INTERVAL);
+    }
+  }
 }
 
 class _HtmlMouse implements PageLoaderMouse {
@@ -84,24 +88,26 @@ class _HtmlMouse implements PageLoaderMouse {
   _HtmlMouse(this.loader);
 
   @override
-  void down(int button, {_ElementPageLoaderElement eventTarget}) {
+  void down(int button,
+      {_ElementPageLoaderElement eventTarget, bool sync: true}) {
     dispatchEvent('mousedown', eventTarget, button);
-    loader.sync();
+    loader.sync(sync);
   }
 
   @override
   void moveTo(_ElementPageLoaderElement element, int xOffset, int yOffset,
-      {_ElementPageLoaderElement eventTarget}) {
+      {_ElementPageLoaderElement eventTarget, bool sync: true}) {
     clientX = (element.node.getBoundingClientRect().left + xOffset).ceil();
     clientY = (element.node.getBoundingClientRect().top + yOffset).ceil();
     dispatchEvent('mousemove', eventTarget);
-    loader.sync();
+    loader.sync(sync);
   }
 
   @override
-  void up(int button, {_ElementPageLoaderElement eventTarget}) {
+  void up(int button,
+      {_ElementPageLoaderElement eventTarget, bool sync: true}) {
     dispatchEvent('mouseup', eventTarget);
-    loader.sync();
+    loader.sync(sync);
   }
 
   int get pageX => window.pageXOffset + clientX;
@@ -190,9 +196,9 @@ abstract class HtmlPageLoaderElement implements PageLoaderElement {
   @override
   String toString() => '$runtimeType<${node.toString()}>';
 
-  void type(String keys) {
+  void type(String keys, {bool sync: true}) {
     _fireKeyPressEvents(node, keys);
-    loader.sync();
+    loader.sync(sync);
   }
 
   // This doesn't work in Dartium due to:
@@ -239,13 +245,13 @@ class _ElementPageLoaderElement extends HtmlPageLoaderElement {
   List<String> get classes => new UnmodifiableListView(node.classes);
 
   @override
-  void click() {
+  void click({bool sync: true}) {
     if (node is OptionElement) {
       _clickOptionElement();
     } else {
       node.click();
     }
-    loader.sync();
+    loader.sync(sync);
   }
 
   void _clickOptionElement() {
@@ -255,7 +261,7 @@ class _ElementPageLoaderElement extends HtmlPageLoaderElement {
   }
 
   @override
-  void type(String keys) {
+  void type(String keys, {bool sync: true}) {
     node.focus();
     _fireKeyPressEvents(node, keys);
     if (node is InputElement || node is TextAreaElement) {
@@ -266,18 +272,19 @@ class _ElementPageLoaderElement extends HtmlPageLoaderElement {
       node.dispatchEvent(new TextEvent('textInput', data: value));
     }
     node.blur();
-    loader.sync();
+    loader.sync(sync);
   }
 
   @override
-  void clear() {
+  void clear({bool sync: true}) {
     if (node is InputElement || node is TextAreaElement) {
       var node = this.node;
       node.value = '';
       node.dispatchEvent(new TextEvent('textInput', data: ''));
     } else {
-      super.clear();
+      super.clear(sync: sync);
     }
+    loader.sync(sync);
   }
 }
 
@@ -297,9 +304,9 @@ class _ShadowRootPageLoaderElement extends HtmlPageLoaderElement {
   @override
   List<String> get classes => super.classes;
   @override
-  void clear() => super.clear();
+  void clear({bool sync: true}) => super.clear(sync: sync);
   @override
-  void click() => super.click();
+  void click({bool sync: true}) => super.click(sync: sync);
   @override
   PageLoaderAttributes get computedStyle => super.computedStyle;
   @override
@@ -326,9 +333,9 @@ class _DocumentPageLoaderElement extends HtmlPageLoaderElement {
   @override
   List<String> get classes => super.classes;
   @override
-  void clear() => super.clear();
+  void clear({bool sync: true}) => super.clear(sync: sync);
   @override
-  void click() => super.click();
+  void click({bool sync: true}) => super.click(sync: sync);
   @override
   PageLoaderAttributes get computedStyle => super.computedStyle;
   @override
@@ -336,13 +343,13 @@ class _DocumentPageLoaderElement extends HtmlPageLoaderElement {
   @override
   PageLoaderAttributes get style => super.style;
   @override
-  void type(String keys) {
+  void type(String keys, {bool sync: true}) {
     // TODO(DrMarcII) consider whether this should be sent to
     // document.activeElement to more closely match WebDriver behavior.
     document.body.focus();
     _fireKeyPressEvents(document.body, keys);
     document.body.blur();
-    loader.sync();
+    loader.sync(sync);
   }
 }
 

--- a/dart/lib/sync/src/interfaces.dart
+++ b/dart/lib/sync/src/interfaces.dart
@@ -43,16 +43,17 @@ abstract class PageLoaderMouse {
   /// specified, PageLoader will attempt to fire the corresponding mouse events
   /// on that target, otherwise it will fire the events on the target that is
   /// under the current mouse location.
-  void down(int button, {PageLoaderElement eventTarget});
+  void down(int button, {PageLoaderElement eventTarget, bool sync: true});
 
   /// Release [button] on the mouse at its current location. If [eventTarget] is
   /// specified, PageLoader will attempt to fire the corresponding mouse events
   /// on that target, otherwise it will fire the events on the target that is
   /// under the current mouse location.
-  void up(int button, {PageLoaderElement eventTarget});
+  void up(int button, {PageLoaderElement eventTarget, bool sync: true});
 
   /// Move the mouse to a location relative to [element].
-  void moveTo(PageLoaderElement element, int xOffset, int yOffset);
+  void moveTo(PageLoaderElement element, int xOffset, int yOffset,
+      {PageLoaderElement eventTarget, bool sync: true});
 }
 
 abstract class PageLoaderElement {
@@ -70,9 +71,9 @@ abstract class PageLoaderElement {
 
   List<PageLoaderElement> getElementsByCss(String selector);
 
-  void clear();
-  void click();
-  void type(String keys);
+  void clear({bool sync: true});
+  void click({bool sync: true});
+  void type(String keys, {bool sync: true});
 }
 
 abstract class PageLoaderAttributes {

--- a/dart/lib/sync/webdriver.dart
+++ b/dart/lib/sync/webdriver.dart
@@ -58,7 +58,8 @@ class _WebDriverMouse implements PageLoaderMouse {
   _WebDriverMouse(this.driver);
 
   @override
-  void down(int button, {_WebElementPageLoaderElement eventTarget}) {
+  void down(int button,
+      {_WebElementPageLoaderElement eventTarget, bool sync: true}) {
     if (eventTarget == null) {
       driver.mouse.down(button);
     } else {
@@ -67,13 +68,19 @@ class _WebDriverMouse implements PageLoaderMouse {
   }
 
   @override
-  void moveTo(_WebElementPageLoaderElement element, int xOffset, int yOffset) {
+  void moveTo(_WebElementPageLoaderElement element, int xOffset, int yOffset,
+      {_WebElementPageLoaderElement eventTarget, bool sync: true}) {
+    if (eventTarget != null) {
+      throw new ArgumentError(
+          'eventTarget not supported on WebDriverPageLoader.mouse.moveTo');
+    }
     driver.mouse.moveTo(
         element: element.context, xOffset: xOffset, yOffset: yOffset);
   }
 
   @override
-  void up(int button, {_WebElementPageLoaderElement eventTarget}) {
+  void up(int button,
+      {_WebElementPageLoaderElement eventTarget, bool sync: true}) {
     if (eventTarget == null) {
       driver.mouse.up(button);
     } else {
@@ -183,11 +190,11 @@ class _WebElementPageLoaderElement extends WebDriverPageLoaderElement {
   }
 
   @override
-  void clear() => context.clear();
+  void clear({bool sync: true}) => context.clear();
   @override
-  void click() => context.click();
+  void click({bool sync: true}) => context.click();
   @override
-  void type(String keys) => context.sendKeys(keys);
+  void type(String keys, {bool sync: true}) => context.sendKeys(keys);
 }
 
 class _WebDriverPageLoaderElement extends WebDriverPageLoaderElement {
@@ -199,7 +206,7 @@ class _WebDriverPageLoaderElement extends WebDriverPageLoaderElement {
   @override
   String get name => '__document__';
   @override
-  void type(String keys) => context.keyboard.sendKeys(keys);
+  void type(String keys, {bool sync: true}) => context.keyboard.sendKeys(keys);
 
   // Overrides to make Analyzer happy.
   @override
@@ -207,9 +214,9 @@ class _WebDriverPageLoaderElement extends WebDriverPageLoaderElement {
   @override
   List<String> get classes => super.classes;
   @override
-  void clear() => super.clear();
+  void clear({bool sync: true}) => super.clear(sync: sync);
   @override
-  void click() => super.click();
+  void click({bool sync: true}) => super.click(sync: sync);
   @override
   PageLoaderAttributes get computedStyle => super.computedStyle;
   @override
@@ -262,9 +269,9 @@ class _ShadowRootPageLoaderElement extends WebDriverPageLoaderElement {
   @override
   List<String> get classes => super.classes;
   @override
-  void clear() => super.clear();
+  void clear({bool sync: true}) => super.clear(sync: sync);
   @override
-  void click() => super.click();
+  void click({bool sync: true}) => super.click(sync: sync);
   @override
   PageLoaderAttributes get computedStyle => super.computedStyle;
   @override
@@ -272,7 +279,7 @@ class _ShadowRootPageLoaderElement extends WebDriverPageLoaderElement {
   @override
   PageLoaderAttributes get style => super.style;
   @override
-  void type(String keys) => super.type(keys);
+  void type(String keys, {bool sync: true}) => super.type(keys, sync: sync);
 }
 
 class _ElementAttributes extends PageLoaderAttributes {

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,16 +1,16 @@
 name: pageloader
-version: 2.0.0-pre.2
+version: 2.0.0-pre.4
 author: Marc Fisher II <fisherii@google.com>
 description: >
   Supports the creation of page objects that can be shared between in-browser tests
   and WebDriver tests.
 homepage: https://github.com/google/pageloader
 environment:
-  sdk: '>=1.9.0 <2.0.0'
+  sdk: '>=1.10.0 <2.0.0'
 dependencies:
-  matcher: '^0.12.0'
-  sync_webdriver: '^1.2.2+1'
+  matcher: '^0.12.0+1'
+  sync_webdriver: '^2.0.0-pre.0'
   webdriver: '^0.10.0-pre.8'
 dev_dependencies:
   path: '^1.3.5'
-  test: '^0.12.0'
+  test: '^0.12.2'

--- a/dart/test/async/src/errors.dart
+++ b/dart/test/async/src/errors.dart
@@ -114,6 +114,11 @@ class PageForPrivateSettersTest {
 
   @ByTagName('table')
   set _table(Table t) => table = t;
+
+  // added to make analyzer happy
+  void setTable(Table t) {
+    _table = t;
+  }
 }
 
 class PageForMultipleFinderTest {

--- a/dart/test/async/src/html_pageloader.dart
+++ b/dart/test/async/src/html_pageloader.dart
@@ -41,7 +41,7 @@ void runTests() {
       html.document.body.onKeyPress.listen((evt) => list.add(evt.charCode));
       await loader.globalContext.type(data);
       expect(new String.fromCharCodes(list), equals(data));
-    });
+    }, onPlatform: {'dartium': new Skip('Key events do not work on dartium')});
   });
 }
 

--- a/dart/test/sync/html_no_shadow_dom_test.dart
+++ b/dart/test/sync/html_no_shadow_dom_test.dart
@@ -50,7 +50,7 @@ void main() {
       html.document.body.onKeyPress.listen((evt) => list.add(evt.charCode));
       plt.loader.globalContext.type(data);
       expect(new String.fromCharCodes(list), equals(data));
-    });
+    }, onPlatform: {'dartium': new Skip('Key events do not work on dartium')});
   });
 
   plt.runTests();

--- a/dart/test/sync/html_test.dart
+++ b/dart/test/sync/html_test.dart
@@ -50,7 +50,7 @@ void main() {
       html.document.body.onKeyPress.listen((evt) => list.add(evt.charCode));
       plt.loader.globalContext.type(data);
       expect(new String.fromCharCodes(list), equals(data));
-    });
+    }, onPlatform: {'dartium': new Skip('Key events do not work on dartium')});
   });
 
   plt.runTests();

--- a/dart/test/sync/page_objects.dart
+++ b/dart/test/sync/page_objects.dart
@@ -185,6 +185,11 @@ class PageForPrivateSettersTest {
 
   @ByTagName('table')
   set _table(Table t) => table = t;
+
+  // added to make analyzer happy
+  void setTable(Table t) {
+    _table = t;
+  }
 }
 
 class PageForStaticFieldsTest extends PageForSimpleTest {

--- a/dart/tool/travis.sh
+++ b/dart/tool/travis.sh
@@ -20,8 +20,8 @@ set -e
 cd dart
 
 # Verify that the libraries are error free.
-grep -Rl --include "*.dart" --exclude-dir="packages" '^library .*;$' lib/ test/ | \
-    xargs dartanalyzer --fatal-warnings
+pub global activate tuneup
+pub global run tuneup check
 
 # Start chromedriver.
 chromedriver --port=4444 --url-base=wd/hub &


### PR DESCRIPTION
 - Enable option in HtmlPageLoader.
 - Since WebDriverPageLoader doesn't sync, option is no-op there.

Change travis script to use tuneup to analyze files.

Increment pubspec versions.

Disable keypress tests on dartium.