### PR TITLE
Improve exceptions in async PageLoader.

### DIFF
--- a/dart/lib/async/html.dart
+++ b/dart/lib/async/html.dart
@@ -25,6 +25,8 @@ export 'src/interfaces.dart';
 
 typedef Future SyncActionFn();
 
+Future _microtask(fn()) => new Future.microtask(fn).whenComplete(() {});
+
 class HtmlPageLoader extends BasePageLoader {
   HtmlPageLoaderElement _globalContext;
 
@@ -67,7 +69,7 @@ class _HtmlMouse implements PageLoaderMouse {
 
   @override
   Future down(int button, {_ElementPageLoaderElement eventTarget}) async {
-    dispatchEvent('mousedown', eventTarget, button);
+    await dispatchEvent('mousedown', eventTarget, button);
     await loader.sync();
   }
 
@@ -76,13 +78,13 @@ class _HtmlMouse implements PageLoaderMouse {
       {_ElementPageLoaderElement eventTarget}) async {
     clientX = (element.node.getBoundingClientRect().left + xOffset).ceil();
     clientY = (element.node.getBoundingClientRect().top + yOffset).ceil();
-    dispatchEvent('mousemove', eventTarget);
+    await dispatchEvent('mousemove', eventTarget);
     await loader.sync();
   }
 
   @override
   Future up(int button, {_ElementPageLoaderElement eventTarget}) async {
-    dispatchEvent('mouseup', eventTarget);
+    await dispatchEvent('mouseup', eventTarget);
     await loader.sync();
   }
 
@@ -96,8 +98,8 @@ class _HtmlMouse implements PageLoaderMouse {
       _borderWidth +
       clientY;
 
-  void dispatchEvent(String type, _ElementPageLoaderElement eventTarget,
-      [int button = 0]) {
+  Future dispatchEvent(String type, _ElementPageLoaderElement eventTarget,
+      [int button = 0]) async {
     var event = new MouseEvent(type,
         button: button,
         clientX: clientX,
@@ -106,9 +108,9 @@ class _HtmlMouse implements PageLoaderMouse {
         screenY: screenY);
 
     if (eventTarget != null) {
-      eventTarget.node.dispatchEvent(event);
+      await _microtask(() => eventTarget.node.dispatchEvent(event));
     } else {
-      currentElement.dispatchEvent(event);
+      await _microtask(() => currentElement.dispatchEvent(event));
     }
   }
 
@@ -177,16 +179,16 @@ abstract class HtmlPageLoaderElement implements PageLoaderElement {
   String toString() => '$runtimeType<$node>';
 
   Future type(String keys) async {
-    _fireKeyPressEvents(node, keys);
+    await _fireKeyPressEvents(node, keys);
     await loader.sync();
   }
 
   // This doesn't work in Dartium due to:
   // https://code.google.com/p/dart/issues/detail?id=13902
-  void _fireKeyPressEvents(Element element, String keys) {
+  Future _fireKeyPressEvents(Element element, String keys) async {
     for (int charCode in keys.codeUnits) {
-      element
-          .dispatchEvent(new KeyEvent('keypress', charCode: charCode).wrapped);
+      await _microtask(() => element
+          .dispatchEvent(new KeyEvent('keypress', charCode: charCode).wrapped));
     }
   }
 
@@ -249,33 +251,34 @@ class _ElementPageLoaderElement extends HtmlPageLoaderElement {
   Stream<String> get classes => new Stream.fromIterable(node.classes);
 
   @override
-  Future click() async {
+  Future click() => capture(() async {
     if (node is OptionElement) {
-      _clickOptionElement();
+      await _clickOptionElement();
     } else {
-      node.click();
+      await _microtask(node.click);
     }
     await loader.sync();
-  }
+  });
 
-  void _clickOptionElement() {
+  Future _clickOptionElement() async {
     OptionElement option = node as OptionElement;
     option.selected = true;
-    option.dispatchEvent(new Event('change'));
+    await _microtask(() => option.dispatchEvent(new Event('change')));
   }
 
   @override
   Future type(String keys) async {
     node.focus();
-    _fireKeyPressEvents(node, keys);
+    await _fireKeyPressEvents(node, keys);
     if (node is InputElement || node is TextAreaElement) {
       // suppress warning by hiding field
       var node = this.node;
       var value = node.value + keys;
       node.value = '';
-      node.dispatchEvent(new TextEvent('textInput', data: value));
+      await _microtask(
+          () => node.dispatchEvent(new TextEvent('textInput', data: value)));
     }
-    node.blur();
+    await _microtask(() => node.blur());
     await loader.sync();
   }
 
@@ -284,7 +287,8 @@ class _ElementPageLoaderElement extends HtmlPageLoaderElement {
     if (node is InputElement || node is TextAreaElement) {
       var node = this.node;
       node.value = '';
-      node.dispatchEvent(new TextEvent('textInput', data: ''));
+      await _microtask(
+          () => node.dispatchEvent(new TextEvent('textInput', data: '')));
     } else {
       throw new PageLoaderException('$this does not support clear.');
     }

--- a/dart/lib/async/html.dart
+++ b/dart/lib/async/html.dart
@@ -25,6 +25,8 @@ export 'src/interfaces.dart';
 
 typedef Future SyncActionFn();
 
+/// execute [fn] as a separate microtask and return a [Future] that completes
+// normally when that [Future] completes (normally or with an error).
 Future _microtask(fn()) => new Future.microtask(fn).whenComplete(() {});
 
 class HtmlPageLoader extends BasePageLoader {

--- a/dart/test/async/src/errors.dart
+++ b/dart/test/async/src/errors.dart
@@ -17,7 +17,7 @@ import 'package:pageloader/async/objects.dart';
 import 'package:test/test.dart';
 import 'shared.dart';
 
-void runTests() {
+runTests() {
   group('error tests', () {
     test('exception on finals', () {
       expect(loader.getInstance(PageForExceptionOnFinalsTest), throws);
@@ -68,6 +68,23 @@ void runTests() {
       expect(loader.getInstance(PageForStaticSettersTest), throws);
     });
   });
+
+  group('check exception stack traces', () async {
+    test('ensure stack trace from getInstance includes test', () async {
+      try {
+        await loader.getInstance(PageForNoMatchingElementTest);
+        fail('expected exception');
+      } on PageLoaderException catch (e, s) {
+        expect(s.toString(), contains('errors.dart'));
+        expect(s.toString(), contains('runTests'));
+      }
+    }, onPlatform: {'js': new Skip('stack traces are not accurate in js')});
+  });
+}
+
+class PageForBadClickTest {
+  @ByTagName('button')
+  PageLoaderElement button;
 }
 
 class PageForExceptionOnFinalsTest {

--- a/dart/test/async/src/html_pageloader.dart
+++ b/dart/test/async/src/html_pageloader.dart
@@ -41,8 +41,8 @@ void runTests() {
       html.document.body.onKeyPress.listen((evt) => list.add(evt.charCode));
       await loader.globalContext.type(data);
       expect(new String.fromCharCodes(list), equals(data));
-    }, onPlatform: {'dartium': new Skip('Key events do not work on dartium')});
-  });
+    }, onPlatform: {'!js': new Skip('Key events do not work on dartium')});
+  }, onPlatform: {'!browser': new Skip('In-browser specific tests')});
 }
 
 class PageForTypingTests {


### PR DESCRIPTION
 - improve exceptions stack traces when creating page objects

Old:
```
PageLoaderException: Unable to load field Symbol("doesntExist") caused by
Bad state: No element
#0      _FieldInfo.setField.<setField_async_body> (package:pageloader/async/src/core.dart:323:7)
#1      _asyncCatchHelper.<anonymous closure> (dart:core-patch/core_patch.dart:14)
#2      StackZoneSpecification.registerBinaryCallback.<anonymous closure>.<anonymous closure> (package:stack_trace/src/stack_zone_specification.dart:145:26)
#3      StackZoneSpecification._run (package:stack_trace/src/stack_zone_specification.dart:205:15)
#4      StackZoneSpecification.registerBinaryCallback.<anonymous closure> (package:stack_trace/src/stack_zone_specification.dart:145:14)
#5      _rootRunBinary (dart:async/zone.dart:923)
#6      _CustomZone.runBinary (dart:async/zone.dart:819)
#7      _Future._propagateToListeners.handleError (dart:async/future_impl.dart:521)
#8      _Future._propagateToListeners (dart:async/future_impl.dart:580)
#9      _Future._completeError (dart:async/future_impl.dart:376)
#10     _Future._asyncCompleteError.<anonymous closure> (dart:async/future_impl.dart:431)
#11     StackZoneSpecification._run (package:stack_trace/src/stack_zone_specification.dart:205:15)
#12     StackZoneSpecification.registerCallback.<anonymous closure> (package:stack_trace/src/stack_zone_specification.dart:124:48)
#13     _rootRun (dart:async/zone.dart:904)
#14     _CustomZone.run (dart:async/zone.dart:803)
#15     _CustomZone.runGuarded (dart:async/zone.dart:709)
#16     _CustomZone.bindCallback.<anonymous closure> (dart:async/zone.dart:734)
#17     _microtaskLoop (dart:async/schedule_microtask.dart:43)
#18     _microtaskLoopEntry (dart:async/schedule_microtask.dart:52)
#19     _ScheduleImmediateHelper._handleMutation (dart:html:42503)
```
New:
```
PageLoaderException: Unable to load field Symbol("doesntExist") caused by
Bad state: No element
package:pageloader/async/html.dart  HtmlPageLoader.getInstance
src/errors.dart 75:22               runTests.<fn>.<async>.<fn>.<async>
dart:html 42503                     _ScheduleImmediateHelper._handleMutation
===== asynchronous gap ===========================
dart:async/future.dart 142          Future.Future.microtask
src/errors.dart                     runTests.<fn>.<async>.<fn>
dart:html 42503                     _ScheduleImmediateHelper._handleMutation
```

- prevent methods in HtmlPageLoader that dispatch events from failing when the event handlers for thos events throw exceptions.