### PR TITLE
Fire input/change events from type() and clear().

### DIFF
--- a/dart/lib/async/html.dart
+++ b/dart/lib/async/html.dart
@@ -281,10 +281,9 @@ class _ElementPageLoaderElement extends HtmlPageLoaderElement {
         if (node is InputElement || node is TextAreaElement) {
           // suppress warning by hiding field
           var node = this.node;
-          var value = node.value + keys;
-          node.value = '';
-          await _microtask(() =>
-              node.dispatchEvent(new TextEvent('textInput', data: value)));
+          node.value += keys;
+          await _microtask(() => node.dispatchEvent(new TextEvent('input')));
+          await _microtask(() => node.dispatchEvent(new TextEvent('change')));
         }
         return blur(sync: false);
       }, sync);
@@ -295,8 +294,8 @@ class _ElementPageLoaderElement extends HtmlPageLoaderElement {
           var node = this.node;
           await focus(sync: false);
           node.value = '';
-          await _microtask(
-              () => node.dispatchEvent(new TextEvent('textInput', data: '')));
+          await _microtask(() => node.dispatchEvent(new TextEvent('input')));
+          await _microtask(() => node.dispatchEvent(new TextEvent('change')));
           return blur(sync: false);
         } else {
           throw new PageLoaderException('$this does not support clear.');


### PR DESCRIPTION
The old approach of using textInput events worked for type() but not for
clear(). It looks like textInput events with an empty data field don't
publish the expected browser events, so anything listening for changes
to the element's value (e.g. Angular) wouldn't see anything.

Firing "input" and "change" should give the expected behavior: "input"
to trigger on-keypress handlers, and "change" to trigger on-enter
handlers.