### PR TITLE
fix analyzer warnings

### DIFF
--- a/dart/lib/async/src/interfaces.dart
+++ b/dart/lib/async/src/interfaces.dart
@@ -39,17 +39,22 @@ abstract class PageLoaderMouse {
   /// specified, PageLoader will attempt to fire the corresponding mouse events
   /// on that target, otherwise it will fire the events on the target that is
   /// under the current mouse location.
-  Future down(MouseButton button, {PageLoaderElement eventTarget, bool sync: true});
+  Future down(MouseButton button,
+      {PageLoaderElement eventTarget, bool sync: true});
 
   /// Release [button] on the mouse at its current location. If [eventTarget] is
   /// specified, PageLoader will attempt to fire the corresponding mouse events
   /// on that target, otherwise it will fire the events on the target that is
   /// under the current mouse location.
-  Future up(MouseButton button, {PageLoaderElement eventTarget, bool sync: true});
+  Future up(MouseButton button,
+      {PageLoaderElement eventTarget, bool sync: true});
 
-  /// Move the mouse to a location relative to [element].
+  /// Move the mouse to a location relative to [element]. If [eventTarget] is
+  /// specified, PageLoader will attempt to fire the corresponding mouse events
+  /// on that target, otherwise it will fire the events on the target that is
+  /// under the current mouse location.
   Future moveTo(PageLoaderElement element, int xOffset, int yOffset,
-      {bool sync: true});
+      {PageLoaderElement eventTarget, bool sync: true});
 }
 
 abstract class PageLoaderElement {

--- a/dart/lib/async/webdriver.dart
+++ b/dart/lib/async/webdriver.dart
@@ -69,18 +69,20 @@ class _WebDriverMouse implements PageLoaderMouse {
       loader.executeSynced(() {
         if (eventTarget == null) {
           return driver.mouse.down(button);
-        } else {
-          return _fireEvent(eventTarget, 'mousedown', button);
         }
+        return _fireEvent(eventTarget, 'mousedown', button);
       }, sync);
 
   @override
   Future moveTo(_WebElementPageLoaderElement element, int xOffset, int yOffset,
-          {bool sync: true}) =>
-      loader.executeSynced(
-          () => driver.mouse.moveTo(
-              element: element.context, xOffset: xOffset, yOffset: yOffset),
-          sync);
+          {_WebElementPageLoaderElement eventTarget, bool sync: true}) =>
+      loader.executeSynced(() {
+        if (eventTarget == null) {
+          return driver.mouse.moveTo(
+              element: element.context, xOffset: xOffset, yOffset: yOffset);
+        }
+        return _fireEvent(eventTarget, 'mousemove');
+      }, sync);
 
   @override
   Future up(MouseButton button,
@@ -88,17 +90,16 @@ class _WebDriverMouse implements PageLoaderMouse {
       loader.executeSynced(() {
         if (eventTarget == null) {
           return driver.mouse.up(button);
-        } else {
-          return _fireEvent(eventTarget, 'mouseup', button);
         }
+        return _fireEvent(eventTarget, 'mouseup', button);
       }, sync);
 
   Future _fireEvent(_WebElementPageLoaderElement eventTarget, String type,
-          MouseButton button) =>
+          [MouseButton button]) =>
       driver.execute(
           "arguments[0].dispatchEvent(new MouseEvent(arguments[1], "
           "{'button' : arguments[2]}));",
-          [eventTarget.context, type, button.value]);
+          [eventTarget.context, type, button?.value]);
 }
 
 abstract class WebDriverPageLoaderElement implements PageLoaderElement {


### PR DESCRIPTION
html.dart's `moveTo` takes an `eventTarget` parameter, which is not specified in the interface of `PageloaderMouse`. This PR fixes that and also adds the parameter to webdriver.dart for consistency