### PR TITLE
Bump async version to 2.0.0

### DIFF
--- a/dart/async/pubspec.yaml
+++ b/dart/async/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pageloader
-version: 2.0.0-pre.14
+version: 2.0.0
 author: Marc Fisher II <fisherii@google.com>
 description: >
   Supports the creation of page objects that can be shared between in-browser tests


### PR DESCRIPTION
There has been some unhappiness about how we use version numbers for this package. My suggestion is: The next release should be version 2.0.0 and we then use semantic versioning (http://semver.org/) going forward.