### PR TITLE
Improve 'No element' error message.

### DIFF
--- a/dart/async/lib/src/core.dart
+++ b/dart/async/lib/src/core.dart
@@ -444,8 +444,11 @@ Future<PageLoaderElement> _getElement(PageLoaderElement context, Finder finder,
   var elements =
       await _getElements(context, finder, filters, displayCheck).toList();
 
-  if (!required && elements.isEmpty) {
-    return null;
+  if (elements.isEmpty) {
+    if (!required) {
+      return null;  
+    }
+    throw new StateError('No element for finder: $finder');
   }
   return elements.single;
 }


### PR DESCRIPTION
Improve 'No element' error message by showing the finder (e.g. ensureTag('item')).