### PR TITLE
Use for ... await ... toList instead of await for

### DIFF
--- a/dart/async/lib/html.dart
+++ b/dart/async/lib/html.dart
@@ -94,7 +94,8 @@ class _HtmlMouse implements PageLoaderMouse {
   int get pageY => window.pageYOffset + clientY;
   int get _borderWidth => (window.outerWidth - window.innerWidth) ~/ 2;
   int get screenX => window.screenLeft + _borderWidth + clientX;
-  int get screenY => window.screenTop +
+  int get screenY =>
+      window.screenTop +
       window.outerHeight -
       window.innerHeight -
       _borderWidth +
@@ -172,7 +173,8 @@ abstract class HtmlPageLoaderElement implements PageLoaderElement {
   int get hashCode => node.hashCode;
 
   @override
-  bool operator ==(other) => other != null &&
+  bool operator ==(other) =>
+      other != null &&
       other.runtimeType == runtimeType &&
       other.node == node &&
       other.loader == loader;
@@ -294,7 +296,7 @@ class _ElementPageLoaderElement extends HtmlPageLoaderElement {
         if (node is SvgElement) {
           return _microtask(() =>
               node.dispatchEvent(new Event.eventType('MouseEvent', 'click')));
-        } 
+        }
 
         return _microtask(node.click);
       }, sync);

--- a/dart/async/lib/src/annotations.dart
+++ b/dart/async/lib/src/annotations.dart
@@ -137,7 +137,8 @@ class InShadowDom implements Finder {
 
   @override
   Stream<PageLoaderElement> findElements(PageLoaderElement context) async* {
-    await for (var el in of.findElements(context).map((e) => e.shadowRoot)) {
+    for (var el
+        in await of.findElements(context).map((e) => e.shadowRoot).toList()) {
       yield* find.findElements(await el);
     }
   }
@@ -201,7 +202,7 @@ class Chain implements Finder {
         elements = annotation.filter(elements);
       } else if (annotation is Finder) {
         elements = (els) async* {
-          await for (var el in els) {
+          for (var el in await els.toList()) {
             yield* annotation.findElements(el);
           }
         }(elements);

--- a/dart/async/lib/src/core.dart
+++ b/dart/async/lib/src/core.dart
@@ -22,7 +22,8 @@ import 'package:stack_trace/stack_trace.dart' as st;
 import 'annotations.dart';
 import 'interfaces.dart';
 
-bool _foldPredicate(st.Frame frame) => frame.isCore ||
+bool _foldPredicate(st.Frame frame) =>
+    frame.isCore ||
     frame.library.contains('package:test/') ||
     frame.library.contains('package:pageloader/') ||
     frame.library.contains('package:unittest/') ||
@@ -387,8 +388,8 @@ class _ListFieldInfo extends _FieldInfo {
     }
     var result = [];
 
-    await for (var el
-        in _getElements(context, _finder, _filters, displayCheck)) {
+    for (var el in await _getElements(context, _finder, _filters, displayCheck)
+        .toList()) {
       result.add(await loader._getInstance(_instanceType, el, displayCheck));
     }
 
@@ -431,7 +432,7 @@ Stream _getElements(PageLoaderElement context, Finder finder,
   if (!displayCheck) {
     yield* elements;
   } else {
-    await for (var el in elements) {
+    for (var el in await elements.toList()) {
       if (await el.displayed) {
         yield el;
       }
@@ -446,7 +447,7 @@ Future<PageLoaderElement> _getElement(PageLoaderElement context, Finder finder,
 
   if (elements.isEmpty) {
     if (!required) {
-      return null;  
+      return null;
     }
     throw new StateError('No element for finder: $finder');
   }

--- a/dart/async/lib/src/interfaces.dart
+++ b/dart/async/lib/src/interfaces.dart
@@ -103,7 +103,7 @@ abstract class ElementFilter implements Filter {
 
   @override
   Stream<PageLoaderElement> filter(Stream<PageLoaderElement> elements) async* {
-    await for (PageLoaderElement el in elements) {
+    for (PageLoaderElement el in await elements.toList()) {
       if (await keep(el)) {
         yield el;
       }

--- a/dart/async/lib/webdriver.dart
+++ b/dart/async/lib/webdriver.dart
@@ -132,7 +132,8 @@ abstract class WebDriverPageLoaderElement implements PageLoaderElement {
   int get hashCode => context.hashCode;
 
   @override
-  bool operator ==(Object other) => other != null &&
+  bool operator ==(Object other) =>
+      other != null &&
       other.runtimeType == runtimeType &&
       (other as WebDriverPageLoaderElement).context == context &&
       (other as WebDriverPageLoaderElement).loader == loader;
@@ -230,7 +231,8 @@ class _WebElementPageLoaderElement extends WebDriverPageLoaderElement {
 
   @override
   Future<String> get innerText async => (await context.driver
-      .execute('return arguments[0].textContent;', [context])).trim();
+          .execute('return arguments[0].textContent;', [context]))
+      .trim();
 
   @override
   Future<String> get visibleText => context.text;

--- a/dart/async/pubspec.yaml
+++ b/dart/async/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pageloader
-version: 2.0.1
+version: 2.0.2
 author: Marc Fisher II <fisherii@google.com>
 description: >
   Supports the creation of page objects that can be shared between in-browser tests


### PR DESCRIPTION
This prevents out-of-order execution (and RPCs) that are caused by async* generators not blocking.

This is a short-term fix that will allow us to use awaitChecking in the webdriver.