### PR TITLE
Remove broken KeyEvent use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ before_script:
   - unzip chromedriver_linux64.zip
   - export PATH=$PATH:$PWD
   - ./dart/async/tool/travis-setup.sh
-  - ./dart/sync/tool/travis-setup.sh
 
 script: 
   - ./dart/async/tool/travis.sh
-  - ./dart/sync/tool/travis.sh

--- a/dart/sync/lib/html.dart
+++ b/dart/sync/lib/html.dart
@@ -197,18 +197,16 @@ abstract class HtmlPageLoaderElement implements PageLoaderElement {
   String toString() => '$runtimeType<${node.toString()}>';
 
   void type(String keys, {bool sync: true}) {
-    _fireKeyPressEvents(node, keys.codeUnits.length);
+    _fireKeyPressEvents(node, keys);
     loader.sync(sync);
   }
 
-  // KeyEvent doesn't work in Dartium due to:
+  // This doesn't work in Dartium due to:
   // https://code.google.com/p/dart/issues/detail?id=13902
-  // There is no reliable way to set the actual key values, so we just fire a number of
-  // key presses instead.
-  void _fireKeyPressEvents(Element element, int numKeys) {
-    for (int i = 0; i < numKeys; ++i) {
+  void _fireKeyPressEvents(Element element, String keys) {
+    for (int charCode in keys.codeUnits) {
       element
-          .dispatchEvent(new KeyboardEvent('keypress'));
+          .dispatchEvent(new KeyEvent('keypress', charCode: charCode).wrapped);
     }
   }
 }
@@ -265,7 +263,7 @@ class _ElementPageLoaderElement extends HtmlPageLoaderElement {
   @override
   void type(String keys, {bool sync: true}) {
     node.focus();
-    _fireKeyPressEvents(node, keys.codeUnits.length);
+    _fireKeyPressEvents(node, keys);
     if (node is InputElement || node is TextAreaElement) {
       // suppress warning by hiding field
       var node = this.node;
@@ -349,7 +347,7 @@ class _DocumentPageLoaderElement extends HtmlPageLoaderElement {
     // TODO(DrMarcII) consider whether this should be sent to
     // document.activeElement to more closely match WebDriver behavior.
     document.body.focus();
-    _fireKeyPressEvents(document.body, keys.codeUnits.length);
+    _fireKeyPressEvents(document.body, keys);
     document.body.blur();
     loader.sync(sync);
   }

--- a/dart/sync/lib/html.dart
+++ b/dart/sync/lib/html.dart
@@ -197,16 +197,18 @@ abstract class HtmlPageLoaderElement implements PageLoaderElement {
   String toString() => '$runtimeType<${node.toString()}>';
 
   void type(String keys, {bool sync: true}) {
-    _fireKeyPressEvents(node, keys);
+    _fireKeyPressEvents(node, keys.codeUnits.length);
     loader.sync(sync);
   }
 
-  // This doesn't work in Dartium due to:
+  // KeyEvent doesn't work in Dartium due to:
   // https://code.google.com/p/dart/issues/detail?id=13902
-  void _fireKeyPressEvents(Element element, String keys) {
-    for (int charCode in keys.codeUnits) {
+  // There is no reliable way to set the actual key values, so we just fire a number of
+  // key presses instead.
+  void _fireKeyPressEvents(Element element, int numKeys) {
+    for (int i = 0; i < numKeys; ++i) {
       element
-          .dispatchEvent(new KeyEvent('keypress', charCode: charCode).wrapped);
+          .dispatchEvent(new KeyboardEvent('keypress'));
     }
   }
 }
@@ -263,7 +265,7 @@ class _ElementPageLoaderElement extends HtmlPageLoaderElement {
   @override
   void type(String keys, {bool sync: true}) {
     node.focus();
-    _fireKeyPressEvents(node, keys);
+    _fireKeyPressEvents(node, keys.codeUnits.length);
     if (node is InputElement || node is TextAreaElement) {
       // suppress warning by hiding field
       var node = this.node;
@@ -347,7 +349,7 @@ class _DocumentPageLoaderElement extends HtmlPageLoaderElement {
     // TODO(DrMarcII) consider whether this should be sent to
     // document.activeElement to more closely match WebDriver behavior.
     document.body.focus();
-    _fireKeyPressEvents(document.body, keys);
+    _fireKeyPressEvents(document.body, keys.codeUnits.length);
     document.body.blur();
     loader.sync(sync);
   }


### PR DESCRIPTION
This removes the use of KeyEvent which is broken in both Dartium (where it seems to silently fail) and DDC (where it creates a runtime type error).
