### PR TITLE
async: Uncomment generics, and fix DDC 1.23.0-dev.11 issue

### DIFF
--- a/dart/async/lib/html.dart
+++ b/dart/async/lib/html.dart
@@ -50,7 +50,7 @@ class HtmlPageLoader extends BasePageLoader {
   }
 
   @override
-  Future/*<T>*/ getInstance/*<T>*/(Type type, [dynamic context]) async {
+  Future<T> getInstance<T>(Type type, [dynamic context]) async {
     if (context != null) {
       if (context is Node) {
         context = new HtmlPageLoaderElement(context, this);

--- a/dart/async/lib/src/interfaces.dart
+++ b/dart/async/lib/src/interfaces.dart
@@ -29,7 +29,7 @@ abstract class PageLoader {
   bool get useShadowDom;
   PageLoaderElement get globalContext;
 
-  Future/*<T>*/ getInstance/*<T>*/(Type type, [dynamic context]);
+  Future<T> getInstance<T>(Type type, [dynamic context]);
 
   PageLoaderMouse get mouse;
 }

--- a/dart/async/lib/webdriver.dart
+++ b/dart/async/lib/webdriver.dart
@@ -45,7 +45,7 @@ class WebDriverPageLoader extends BasePageLoader {
   WebDriverPageLoaderElement get globalContext => _globalContext;
 
   @override
-  Future/*<T>*/ getInstance/*<T>*/(Type type, [dynamic context]) async {
+  Future<T> getInstance<T>(Type type, [dynamic context]) async {
     if (context != null) {
       if (context is wd.SearchContext) {
         context = new WebDriverPageLoaderElement(context, this);


### PR DESCRIPTION
In DDC 1.23.0-dev.11, `_ClassInfo`'s factory constructor can result in runtime errors, because of changes to inference. Basically, the `_classInfoCache` is declared to be a `Map<ClassMirror, _ClassInfo>`, where `_ClassInfo`'s type is unbound. So when the factory constructor is first called, say with `_ClassInfo<X>`, and the first entrant makes its way into `_classInfoCache`, then DDC is binding the type parameters to `Map<ClassMirror, _ClassInfo<X>>`. So then the second time the factory constructor is called, if it is with `_ClassInfo<Y>`, then Y was expected to be X ,and a runtime error is thrown.

This was tested on code in Google, and it looks good.

The only lines changed in the factory constructor are lines 102, 103, and 104. The rest are the result of dartfmt, which GitHub unfortunately highlights as huge changes.