### PR TITLE
Use the default target name

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,5 @@
 targets:
-  _library:
+  $default:
     sources: ["lib/**"]
     builders:
       built_value_generator|built_value:


### PR DESCRIPTION
A target with the default name is supposed to be required by
`build_config` but the check was missing.

See https://github.com/dart-lang/build/issues/1426