### PR TITLE
New temporary file restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ abstract class MyPO {
 }
 ```
 
+**There are an addition two requirements for Dart files containing page objects:**
+1. Must be within either `/test/...` or `/testing/...` folder
+2. Must be suffixed with `_po.dart`
+
+For example: 
+1. `lib/po_containing_file.dart` will not work
+2. `lib/foo/my_po.dart` will not work
+3. `test/foo/bar/special_po.dart` will work
+4. `testing/foo/special_po.dart` will work
+
+The above two restrictions are only **temporary** and will be relaxed in the future.
+But by convention, these two forms should be maintained even after the
+hard restriction is relaxed. 
+
 Above is the bare minimum boilerplate code needed for a PageObject.
 Feel free to cut/paste this when starting new page objects.
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ abstract class MyPO {
 }
 ```
 
-**PageObject containing Dart files must be within either in `test/...` or
-`testing/...` directory for the code generation step.**
+**PageObject containing Dart files must be in `test/...` directory
+for the code generation step to occur.**
 
 For example:
 1. `test/page_objects/special_po.dart` will work
-2. `testing/foo/page_objects/special_po.dart` will work
+2. `test/src/page_objects/special_po.dart` will work
 3. `lib/src/foo/my_po.dart` will not work
     * File is located in `lib/...` directory; must be in `test/...`
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For example:
 1. `test/page_objects/special_po.dart` will work
 2. `testing/foo/page_objects/special_po.dart` will work
 3. `lib/src/foo/my_po.dart` will not work
-    * File is located in `lib/...` directory
+    * File is located in `lib/...` directory; must be in `test/...`
 
 The above restriction is only **temporary** and will be relaxed in the future.
 But by convention, this should be done even after the requirement is relaxed.

--- a/README.md
+++ b/README.md
@@ -52,19 +52,16 @@ abstract class MyPO {
 }
 ```
 
-**There are an addition two requirements for Dart files containing page objects:**
-1. Must be within either `/test/...` or `/testing/...` folder
-2. Must be suffixed with `_po.dart`
+**PageObject containing Dart files must be within either in `test/...` or
+`testing/...` directory for the code generation step.**
 
 For example: 
-1. `lib/po_containing_file.dart` will not work
-2. `lib/foo/my_po.dart` will not work
-3. `test/foo/bar/special_po.dart` will work
-4. `testing/foo/special_po.dart` will work
+1. `lib/src/foo/my_po.dart` will not work
+2. `test/foo/bar/special_po.dart` will work
+3. `testing/foo/special_po.dart` will work
 
-The above two restrictions are only **temporary** and will be relaxed in the future.
-But by convention, these two forms should be maintained even after the
-hard restriction is relaxed. 
+The above restriction is only **temporary** and will be relaxed in the future.
+But by convention, this should be done even after the requirement is relaxed.
 
 Above is the bare minimum boilerplate code needed for a PageObject.
 Feel free to cut/paste this when starting new page objects.

--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ abstract class MyPO {
 **PageObject containing Dart files must be within either in `test/...` or
 `testing/...` directory for the code generation step.**
 
-For example: 
-1. `lib/src/foo/my_po.dart` will not work
-2. `test/foo/bar/special_po.dart` will work
-3. `testing/foo/special_po.dart` will work
+For example:
+1. `test/page_objects/special_po.dart` will work
+2. `testing/foo/page_objects/special_po.dart` will work
+3. `lib/src/foo/my_po.dart` will not work
+    * File is located in `lib/...` directory
 
 The above restriction is only **temporary** and will be relaxed in the future.
 But by convention, this should be done even after the requirement is relaxed.

--- a/build.yaml
+++ b/build.yaml
@@ -28,4 +28,4 @@ builders:
     auto_apply: dependents
     build_to: source
     defaults:
-      generate_for: ["test/**", "testing/**"]
+      generate_for: ["test/**/*_po.dart", "testing/**/*_po.dart"]

--- a/build.yaml
+++ b/build.yaml
@@ -28,4 +28,4 @@ builders:
     auto_apply: dependents
     build_to: source
     defaults:
-      generate_for: ["test/**", "testing/**"]
+      generate_for: ["test/**"]

--- a/build.yaml
+++ b/build.yaml
@@ -28,4 +28,4 @@ builders:
     auto_apply: dependents
     build_to: source
     defaults:
-      generate_for: ["test/**/*_po.dart", "testing/**/*_po.dart"]
+      generate_for: ["test/**", "testing/**"]

--- a/lib/src/webdriver/webdriver_page_loader_element.dart
+++ b/lib/src/webdriver/webdriver_page_loader_element.dart
@@ -268,8 +268,8 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
 
   @override
   Rectangle get offset {
-    final Map<String, num> rect =
-        _retryWhenStale(() => _driver.execute('''return {
+    final rect =
+        _retryWhenStale<Map>(() => _driver.execute('''return {
           left: arguments[0].offsetLeft,
           top: arguments[0].offsetTop,
           width: arguments[0].offsetWidth,
@@ -281,7 +281,7 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
 
   @override
   Rectangle getBoundingClientRect() {
-    final Map<String, num> rect = _retryWhenStale(() => _driver.execute(
+    final rect = _retryWhenStale<Map>(() => _driver.execute(
         'return arguments[0].getBoundingClientRect();', [_single.context]));
     return new Rectangle<num>(
         rect['left'], rect['top'], rect['width'], rect['height']);


### PR DESCRIPTION
Adding a temporary restriction until build_runner's long-term solution is implemented. This should avoid the need for users to have a `build.yaml`.

Also minor fix with dart 2 runtime that will occur in a future sdk version.