### PR TITLE
Fix utils/matcher

### DIFF
--- a/lib/src/api/exceptions.dart
+++ b/lib/src/api/exceptions.dart
@@ -15,6 +15,11 @@ library pageloader.api.exceptions;
 
 import 'page_loader_element_interface.dart';
 
+class FoundZeroElementsInSingleException extends PageLoaderException {
+  const FoundZeroElementsInSingleException(PageLoaderElement element)
+      : super.withContext('Found 0 elements in _single', element);
+}
+
 class PageLoaderException {
   final String message;
   final PageLoaderElement element;

--- a/lib/src/html/html_page_loader_element.dart
+++ b/lib/src/html/html_page_loader_element.dart
@@ -120,8 +120,7 @@ class HtmlPageLoaderElement implements PageLoaderElement {
 
     final elems = elements;
     if (elems.isEmpty) {
-      throw new PageLoaderException.withContext(
-          'Found 0 elements in _single', this);
+      throw new FoundZeroElementsInSingleException(this);
     } else if (elems.length > 1) {
       throw new PageLoaderException.withContext(
           'Found multiple elements in _single', this);
@@ -219,7 +218,13 @@ class HtmlPageLoaderElement implements PageLoaderElement {
 
   @override
   bool get exists {
-    final count = (elements).length;
+    List<Element> foundElements;
+    try {
+      foundElements = elements;
+    } on FoundZeroElementsInSingleException {
+      return false;
+    }
+    final count = foundElements.length;
     if (count == 1)
       return true;
     else if (count == 0) return false;

--- a/lib/src/webdriver/webdriver_page_loader_element.dart
+++ b/lib/src/webdriver/webdriver_page_loader_element.dart
@@ -139,8 +139,7 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
 
     final elems = elements;
     if (elems.isEmpty) {
-      throw new PageLoaderException.withContext(
-          'Found 0 elements in _single', this);
+      throw new FoundZeroElementsInSingleException(this);
     } else if (elems.length > 1) {
       throw new PageLoaderException.withContext(
           'Found multiple elements in _single', this);
@@ -258,7 +257,13 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
 
   @override
   bool get exists {
-    final count = elements.length;
+    List<sync_wd.WebElement> foundElements;
+    try {
+      foundElements = elements;
+    } on FoundZeroElementsInSingleException {
+      return false;
+    }
+    final count = foundElements.length;
     if (count == 1)
       return true;
     else if (count == 0) return false;

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import 'src/api/annotation_interfaces.dart';
+import 'src/api/exceptions.dart' show PageLoaderException;
 import 'src/api/page_loader_element_interface.dart';
 import 'src/api/page_object_list_interface.dart';
 
@@ -39,8 +40,11 @@ bool exists(item) {
   }
   try {
     return rootElementOf(item).exists;
+  } on PageLoaderException catch (e) {
+    // On PageLoaderException, throw it back.
+    throw e;
   } catch (_) {
-    throw new PageLoaderArgumentError.existsError();
+    throw new PageLoaderArgumentError.onWrongType('exists/notExists');
   }
 }
 
@@ -48,23 +52,13 @@ bool exists(item) {
 bool notExists(item) => !exists(item);
 
 /// Checks if a PageLoaderElement/PageObject contains given class.
-bool hasClass(item, String className) {
-  try {
-    return rootElementOf(item).classes.contains(className);
-  } catch (_) {
-    throw new PageLoaderArgumentError.hasClassError();
-  }
-}
+bool hasClass(item, String className) =>
+    _rootElementOfAndCheck(item, 'hasClass').classes.contains(className);
 
 /// Checks if a PageLoaderElement/PageObject is displayed based on "display"
 /// style.
-bool isDisplayed(item) {
-  try {
-    return rootElementOf(item).displayed;
-  } catch (_) {
-    throw new PageLoaderArgumentError.isDisplayedError();
-  }
-}
+bool isDisplayed(item) =>
+    _rootElementOfAndCheck(item, 'isDisplayed/isNotDisplayed').displayed;
 
 /// Checks if a PageLoaderElement/PageObject is not displayed based on
 /// "display" style.
@@ -77,38 +71,24 @@ const _hidden = const ['hidden', 'collapse'];
 ///
 /// A PageLoaderElement/PageObject is considered hidden if its `visibility`
 /// style is either `hidden` or `collapse`.
-bool isHidden(item) {
-  try {
-    return _hidden.contains(rootElementOf(item).computedStyle['visibility']);
-  } catch (_) {
-    throw new PageLoaderArgumentError.isHiddenError();
-  }
-}
+bool isHidden(item) =>
+    _hidden.contains(_rootElementOfAndCheck(item, 'isHidden/isNotHidden')
+        .computedStyle['visibility']);
 
 /// Checks if PageLoaderElement/PageObject is not hidden based on "visibility"
 /// style.
 bool isNotHidden(item) => !isHidden(item);
 
 /// Checks if PageLoaderElement/PageObject is focused.
-bool isFocused(item) {
-  try {
-    return rootElementOf(item).isFocused;
-  } catch (_) {
-    throw new PageLoaderArgumentError.isFocusedError();
-  }
-}
+bool isFocused(item) =>
+    _rootElementOfAndCheck(item, 'isFocused/isNotFocused').isFocused;
 
 /// Checks if PageLoaderElement/PageObject is not focused.
 bool isNotFocused(item) => !isFocused(item);
 
 /// Gets the innerText of a PageLoaderElement/PageObject.
-String getInnerText(item) {
-  try {
-    return rootElementOf(item).innerText;
-  } catch (_) {
-    throw new PageLoaderArgumentError.innerTextError();
-  }
-}
+String getInnerText(item) =>
+    _rootElementOfAndCheck(item, 'getInnerText').innerText;
 
 /// Function for PageObject constructor. Typically in form:
 ///   (c) => new SomePO.create(c)
@@ -137,34 +117,36 @@ PageLoaderElement rootElementOf(item) {
   try {
     return item.$root;
   } catch (_) {
-    throw new PageLoaderArgumentError.rootElementOfError();
+    throw new PageLoaderArgumentError.onWrongType('rootElementOf');
   }
+}
+
+/// First checks to see if 'item' is either PageLoaderElement or PageObject.
+/// If neither, throws an error.
+/// Then checks to see if 'item' exists. If it doesn't exist, throws an error.
+/// Returns 'item' as PageLoaderElement.
+PageLoaderElement _rootElementOfAndCheck(item, String f) {
+  PageLoaderElement _root;
+  try {
+    _root = rootElementOf(item);
+  } catch (_) {
+    throw new PageLoaderArgumentError.onWrongType(f);
+  }
+  if (!_root.exists) {
+    throw new PageLoaderArgumentError.onNonExisting(f);
+  }
+  return _root;
 }
 
 class PageLoaderArgumentError extends ArgumentError {
   PageLoaderArgumentError._(String message) : super(message);
 
-  static String _message(String f) => "'$f' may only be called on PageObjects "
-      'or PageLoaderElements';
+  factory PageLoaderArgumentError.onWrongType(String f) =>
+      new PageLoaderArgumentError._("'$f' may only be called on PageObjects "
+          "or PageLoaderElements");
 
-  factory PageLoaderArgumentError.existsError() =>
-      new PageLoaderArgumentError._(_message('exists/notExists'));
-
-  factory PageLoaderArgumentError.hasClassError() =>
-      new PageLoaderArgumentError._(_message('hasClass'));
-
-  factory PageLoaderArgumentError.isDisplayedError() =>
-      new PageLoaderArgumentError._(_message('isDisplayed/isNotDisplayed'));
-
-  factory PageLoaderArgumentError.isHiddenError() =>
-      new PageLoaderArgumentError._(_message('isHidden/isNotHidden'));
-
-  factory PageLoaderArgumentError.isFocusedError() =>
-      new PageLoaderArgumentError._(_message('isFocused/isNotFocused'));
-
-  factory PageLoaderArgumentError.innerTextError() =>
-      new PageLoaderArgumentError._(_message('getInnerText/hasInnerText'));
-
-  factory PageLoaderArgumentError.rootElementOfError() =>
-      new PageLoaderArgumentError._(_message('rootElementOf'));
+  factory PageLoaderArgumentError.onNonExisting(String f) =>
+      new PageLoaderArgumentError._("'$f' is being called on a non-existent "
+          "PageObject or PageLoaderElement. If this "
+          "is intentional, use 'exists' instead.");
 }

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -144,7 +144,7 @@ PageLoaderElement rootElementOf(item) {
 class PageLoaderArgumentError extends ArgumentError {
   PageLoaderArgumentError._(String message) : super(message);
 
-  static String _message(String f) => "'$f' may only be called on PageObjects"
+  static String _message(String f) => "'$f' may only be called on PageObjects "
       'or PageLoaderElements';
 
   factory PageLoaderArgumentError.existsError() =>


### PR DESCRIPTION
Improve logic on pageloader utils and matchers.

`exists` method on `PageLoaderElement` no longer throws an error when... it doesn't exist. Weird subroutine logic made it throw an error when `0 elements are found` - indicating the element doesn't exist. In other words, `exists` should just return `false`. This has been fixed. (All other method/getter calls to the element will still throw error though.)

For utils and methods, any `PageLoaderElement` based methods will perform two checks:
1. Ensure that either a `PageLoaderElement` or some PageObject is passed.
2. If (1) is satisfied, ensure that it exists. If it doesn't exist, throw an error indicating that a method was called on a non-existent `PageLoaderElement`.

Failures and errors will be more specific now.