### PR TITLE
Change @ByDebugId and utils/matchers

### DIFF
--- a/lib/src/api/annotations.dart
+++ b/lib/src/api/annotations.dart
@@ -78,16 +78,49 @@ class ByCss implements CssFinder {
 /// Finds element by debugid.
 class ByDebugId implements CssFinder {
   final String _debugId;
-  final String _debugAnnotation;
+  final bool useDash;
+  final bool usePlain;
+  final bool useCamelCase;
 
-  /// @ByDebugId('x') looks for 'debugid="x"'.
+  /// @ByDebugId('x') looks for debug id attribute. By default (no args),
+  /// looks for 'debugid=x', 'debug-id=x', or 'debugId="x"'.
   ///
-  /// @ByDebugId('x', useDash:true) looks for 'debug-id="x"'.
-  const ByDebugId(this._debugId, {bool useDash: false})
-      : _debugAnnotation = 'debug${useDash? '-' : ''}id';
+  /// Args:
+  ///   `useDash` looks for 'debug-id'
+  ///   `usePlain` looks for 'debugid'
+  ///   `useCamelCase` looks for 'debugId'
+  ///
+  /// If one or more named args are provided, looks for only those debug ids:
+  ///   Example: @ByDebugId('x', useDash: true, usePlain: true)
+  ///       looks for 'debug-id=x' or 'debugid=x'
+  const ByDebugId(this._debugId,
+      {this.useDash: false, this.usePlain: false, this.useCamelCase: false});
+
+  String get _default => '$_useDash,$_usePlain,$_useCamelCase';
+
+  String get _useDash => '[debug-id=$_debugId]';
+
+  String get _usePlain => '[debugid=$_debugId]';
+
+  String get _useCamelCase => '[debugId=$_debugId]';
 
   @override
-  String get cssSelector => "[$_debugAnnotation='$_debugId']";
+  String get cssSelector {
+    final selectors = <String>[];
+    if (useDash) {
+      selectors.add(_useDash);
+    }
+    if (usePlain) {
+      selectors.add(_usePlain);
+    }
+    if (useCamelCase) {
+      selectors.add(_useCamelCase);
+    }
+    if (selectors.isEmpty) {
+      return _default;
+    }
+    return selectors.join(',');
+  }
 
   @override
   String toString() => '@ByDebugId("$_debugId")';

--- a/lib/src/api/exceptions.dart
+++ b/lib/src/api/exceptions.dart
@@ -20,6 +20,11 @@ class FoundZeroElementsInSingleException extends PageLoaderException {
       : super.withContext('Found 0 elements in _single', element);
 }
 
+class FoundMultipleElementsInSingleException extends PageLoaderException {
+  const FoundMultipleElementsInSingleException(PageLoaderElement element)
+      : super.withContext('Found multiple elements in _single', element);
+}
+
 class PageLoaderException {
   final String message;
   final PageLoaderElement element;

--- a/lib/src/html/html_page_loader_element.dart
+++ b/lib/src/html/html_page_loader_element.dart
@@ -216,17 +216,14 @@ class HtmlPageLoaderElement implements PageLoaderElement {
       _retryWhenStale(() => document.activeElement == _single);
 
   @override
-  bool get exists => _retryWhenStale(() {
-        try {
-          _single;
-        } on FoundZeroElementsInSingleException {
-          return false;
-        } on FoundMultipleElementsInSingleException {
-          throw new PageLoaderException.withContext(
-              'Found multiple elements on call to exists', this);
-        }
-        return true;
-      });
+  bool get exists {
+    final count = (elements).length;
+    if (count == 1)
+      return true;
+    else if (count == 0) return false;
+    throw new PageLoaderException.withContext(
+        'Found $count elements on call to exists', this);
+  }
 
   @override
   Rectangle get offset => _retryWhenStale(() => _single.offset);

--- a/lib/src/webdriver/webdriver_page_loader_element.dart
+++ b/lib/src/webdriver/webdriver_page_loader_element.dart
@@ -255,17 +255,14 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
   bool get isFocused => _retryWhenStale(() => _single == _driver.activeElement);
 
   @override
-  bool get exists => _retryWhenStale(() {
-        try {
-          _single;
-        } on FoundZeroElementsInSingleException {
-          return false;
-        } on FoundMultipleElementsInSingleException {
-          throw new PageLoaderException.withContext(
-              'Found multiple elements on call to exists', this);
-        }
-        return true;
-      });
+  bool get exists {
+    final count = elements.length;
+    if (count == 1)
+      return true;
+    else if (count == 0) return false;
+    throw new PageLoaderException.withContext(
+        'Found $count elements on call to exists', this);
+  }
 
   @override
   Rectangle get offset {

--- a/test/data/html_setup.dart
+++ b/test/data/html_setup.dart
@@ -48,8 +48,9 @@ html.Element setUp() {
       <a href="test.html" id="anchor">test</a>
       <img src="test.png">
       <select id='select1'>
-        <option id='option1' value='value 1' debugid="option">option 1</option>
-        <option id='option2' value='value 2' debug-id="option">option 2</option>
+        <option id='option1' value='value 1' debugid="option1">option 1</option>
+        <option id='option2' value='value 2' debug-id="option2">option 2</option>
+        <option id='option3' value='value 3' debugId="option3">option 3</option>
       </select>
       <textarea id='textarea'></textarea>
       <div class="outer-div">

--- a/test/data/webdriver_test_page.html
+++ b/test/data/webdriver_test_page.html
@@ -67,8 +67,9 @@ limitations under the License.
 <a href="test.html" id="anchor">test</a>
 <img src="test.png">
 <select id='select1'>
-  <option id='option1' value='value 1' debugid="option">option 1</option>
-  <option id='option2' value='value 2' debug-id="option">option 2</option>
+  <option id='option1' value='value 1' debugid="option1">option 1</option>
+  <option id='option2' value='value 2' debug-id="option2">option 2</option>
+  <option id='option3' value='value 3' debugId="option3">option 3</option>
 </select>
 <textarea id='textarea'></textarea>
 <div class="outer-div">

--- a/test/examples/correct/unannotated.g.dart
+++ b/test/examples/correct/unannotated.g.dart
@@ -27,7 +27,7 @@ class $Unannotated extends Unannotated with $$Unannotated {
     return returnMe;
   }
 
-  void set myField(bool setValue) {
+  set myField(bool setValue) {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Unannotated', 'myField');
     }

--- a/test/src/annotations.dart
+++ b/test/src/annotations.dart
@@ -81,6 +81,10 @@ void runTests(GetNewContext contextGenerator) {
       final page = new DebugIds.create(contextGenerator());
       expect(page.option1.innerText, 'option 1');
       expect(page.option2.innerText, 'option 2');
+      expect(page.option3.innerText, 'option 3');
+      expect(page.usePlain.innerText, 'option 1');
+      expect(page.useDash.innerText, 'option 2');
+      expect(page.useCamelCase.innerText, 'option 3');
     });
   });
 
@@ -238,11 +242,23 @@ abstract class DebugIds {
   DebugIds();
   factory DebugIds.create(PageLoaderElement context) = $DebugIds.create;
 
-  @ByDebugId('option')
+  @ByDebugId('option1')
   PageLoaderElement get option1;
 
-  @ByDebugId('option', useDash: true)
+  @ByDebugId('option2')
   PageLoaderElement get option2;
+
+  @ByDebugId('option3')
+  PageLoaderElement get option3;
+
+  @ByDebugId('option1', usePlain: true)
+  PageLoaderElement get usePlain;
+
+  @ByDebugId('option2', useDash: true)
+  PageLoaderElement get useDash;
+
+  @ByDebugId('option3', useCamelCase: true)
+  PageLoaderElement get useCamelCase;
 }
 
 class PseudoByTagName implements CssFinder {

--- a/test/src/annotations.g.dart
+++ b/test/src/annotations.g.dart
@@ -369,7 +369,7 @@ class $$DebugIds {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('DebugIds', 'option1');
     }
-    final element = $__root__.createElement(const ByDebugId('option'), [], []);
+    final element = $__root__.createElement(const ByDebugId('option1'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('DebugIds', 'option1');
@@ -381,11 +381,61 @@ class $$DebugIds {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('DebugIds', 'option2');
     }
-    final element = $__root__
-        .createElement(const ByDebugId('option', useDash: true), [], []);
+    final element = $__root__.createElement(const ByDebugId('option2'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('DebugIds', 'option2');
+    }
+    return returnMe;
+  }
+
+  PageLoaderElement get option3 {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('DebugIds', 'option3');
+    }
+    final element = $__root__.createElement(const ByDebugId('option3'), [], []);
+    final returnMe = element;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('DebugIds', 'option3');
+    }
+    return returnMe;
+  }
+
+  PageLoaderElement get usePlain {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('DebugIds', 'usePlain');
+    }
+    final element = $__root__
+        .createElement(const ByDebugId('option1', usePlain: true), [], []);
+    final returnMe = element;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('DebugIds', 'usePlain');
+    }
+    return returnMe;
+  }
+
+  PageLoaderElement get useDash {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('DebugIds', 'useDash');
+    }
+    final element = $__root__
+        .createElement(const ByDebugId('option2', useDash: true), [], []);
+    final returnMe = element;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('DebugIds', 'useDash');
+    }
+    return returnMe;
+  }
+
+  PageLoaderElement get useCamelCase {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('DebugIds', 'useCamelCase');
+    }
+    final element = $__root__
+        .createElement(const ByDebugId('option3', useCamelCase: true), [], []);
+    final returnMe = element;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('DebugIds', 'useCamelCase');
     }
     return returnMe;
   }

--- a/test/src/basic.dart
+++ b/test/src/basic.dart
@@ -106,8 +106,8 @@ void runTests(GetNewContext contextGenerator) {
       } catch (e) {
         expect(
             e.toString(),
-            contains('PageLoaderException: Found multiple elements '
-                'on call to exists'));
+            contains(
+                'PageLoaderException: Found 4 elements on call to exists'));
       }
     });
 

--- a/test/src/basic.dart
+++ b/test/src/basic.dart
@@ -106,8 +106,8 @@ void runTests(GetNewContext contextGenerator) {
       } catch (e) {
         expect(
             e.toString(),
-            contains(
-                'PageLoaderException: Found 4 elements on call to exists'));
+            contains('PageLoaderException: Found multiple elements '
+                'on call to exists'));
       }
     });
 


### PR DESCRIPTION
@ByDebugId now, by default, tries to match on 'debugid'/'debug-id'/'debugID'. Now adding in optional named parameters make it exclusively match on the passed variant of debugid.

Utils and matchers now no-longer swallows errors and behaves more exactly.