### PR TITLE
Upgrade to source_gen 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
+## 3.0.0-beta.1
+
+- Update to the latest `source_gen`. This generator can now be used with other
+  generators that want to write to .g.dart files without a manual build script.
+- Breaking: The `header` builder option is no longer supported.
+
 ## 3.0.0-beta
+
 - `@EnsureTag` is marked as deprecated. Will be removed in a future
   release.
 - Add listeners into `WebdriverPageLoaderElement` if searching for

--- a/build.yaml
+++ b/build.yaml
@@ -13,19 +13,14 @@ targets:
         enabled: false
       pageloader|pageloader:
         enabled: true
-        options:
-          header: |+
-           // GENERATED CODE - DO NOT MODIFY BY HAND
-
-           // ignore_for_file: unused_field, non_constant_identifier_names
-           // ignore_for_file: overridden_fields, annotate_overrides
 
 builders:
   pageloader:
     import: "package:pageloader/builder.dart"
     builder_factories: ["pageloaderBuilder"]
-    build_extensions: {".dart": [".g.dart"]}
+    build_extensions: {".dart": [".pageloader.g.part"]}
     auto_apply: dependents
-    build_to: source
+    build_to: cache
+    applies_builders: ["source_gen|combining_builder"]
     defaults:
       generate_for: ["test/**"]

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -34,9 +34,8 @@ Builder pageloaderBuilder(BuilderOptions options) {
   // elsewhere.
   final optionsMap = new Map<String, dynamic>.from(options.config);
 
-  final builder = new PartBuilder([
-    new PageObjectGenerator(),
-  ], header: optionsMap.remove('header') as String);
+  final builder =
+      new SharedPartBuilder([const PageObjectGenerator()], 'pageloader');
 
   if (optionsMap.isNotEmpty) {
     if (log == null) {

--- a/lib/src/generators/methods/core_method_information.g.dart
+++ b/lib/src/generators/methods/core_method_information.g.dart
@@ -9,7 +9,9 @@ part of pageloader.core_method_information;
 // ignore_for_file: always_put_control_body_on_new_line
 // ignore_for_file: annotate_overrides
 // ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
 // ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: omit_local_variable_types
 // ignore_for_file: prefer_expression_function_bodies
 // ignore_for_file: sort_constructors_first

--- a/lib/src/generators/methods/getter.g.dart
+++ b/lib/src/generators/methods/getter.g.dart
@@ -9,7 +9,9 @@ part of pageloader.getter;
 // ignore_for_file: always_put_control_body_on_new_line
 // ignore_for_file: annotate_overrides
 // ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
 // ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: omit_local_variable_types
 // ignore_for_file: prefer_expression_function_bodies
 // ignore_for_file: sort_constructors_first

--- a/lib/src/generators/methods/iterable_finder_method.g.dart
+++ b/lib/src/generators/methods/iterable_finder_method.g.dart
@@ -9,7 +9,9 @@ part of pageloader.iterable_finder_method;
 // ignore_for_file: always_put_control_body_on_new_line
 // ignore_for_file: annotate_overrides
 // ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
 // ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: omit_local_variable_types
 // ignore_for_file: prefer_expression_function_bodies
 // ignore_for_file: sort_constructors_first

--- a/lib/src/generators/methods/list_finder_method.g.dart
+++ b/lib/src/generators/methods/list_finder_method.g.dart
@@ -9,7 +9,9 @@ part of pageloader.list_finder_method;
 // ignore_for_file: always_put_control_body_on_new_line
 // ignore_for_file: annotate_overrides
 // ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
 // ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: omit_local_variable_types
 // ignore_for_file: prefer_expression_function_bodies
 // ignore_for_file: sort_constructors_first

--- a/lib/src/generators/methods/mouse_finder_method.g.dart
+++ b/lib/src/generators/methods/mouse_finder_method.g.dart
@@ -9,7 +9,9 @@ part of pageloader.mouse_finder_method;
 // ignore_for_file: always_put_control_body_on_new_line
 // ignore_for_file: annotate_overrides
 // ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
 // ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: omit_local_variable_types
 // ignore_for_file: prefer_expression_function_bodies
 // ignore_for_file: sort_constructors_first

--- a/lib/src/generators/methods/setter.g.dart
+++ b/lib/src/generators/methods/setter.g.dart
@@ -9,7 +9,9 @@ part of pageloader.setter;
 // ignore_for_file: always_put_control_body_on_new_line
 // ignore_for_file: annotate_overrides
 // ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
 // ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: omit_local_variable_types
 // ignore_for_file: prefer_expression_function_bodies
 // ignore_for_file: sort_constructors_first

--- a/lib/src/generators/methods/single_finder_method.g.dart
+++ b/lib/src/generators/methods/single_finder_method.g.dart
@@ -9,7 +9,9 @@ part of pageloader.single_finder_method;
 // ignore_for_file: always_put_control_body_on_new_line
 // ignore_for_file: annotate_overrides
 // ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
 // ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: omit_local_variable_types
 // ignore_for_file: prefer_expression_function_bodies
 // ignore_for_file: sort_constructors_first

--- a/lib/src/generators/methods/unannotated_method.g.dart
+++ b/lib/src/generators/methods/unannotated_method.g.dart
@@ -9,7 +9,9 @@ part of pageloader.unannotated_method;
 // ignore_for_file: always_put_control_body_on_new_line
 // ignore_for_file: annotate_overrides
 // ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
 // ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: omit_local_variable_types
 // ignore_for_file: prefer_expression_function_bodies
 // ignore_for_file: sort_constructors_first

--- a/lib/src/generators/pageobject_generator.dart
+++ b/lib/src/generators/pageobject_generator.dart
@@ -27,6 +27,17 @@ import 'methods/core.dart' as core;
 class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
   const PageObjectGenerator();
 
+  @override
+  FutureOr<String> generate(LibraryReader library, BuildStep buildStep) async {
+    final result = await super.generate(library, buildStep);
+    if (result?.isEmpty ?? true) return '';
+    const ignore =
+        '// ignore_for_file: private_collision_in_mixin_application\n'
+        '// ignore_for_file: unused_field, non_constant_identifier_names\n'
+        '// ignore_for_file: overridden_fields, annotate_overrides\n';
+    return '$ignore$result';
+  }
+
   /// Generates a page object, as source String, for a class annotated with
   /// '@PageObject()'.
   @override
@@ -35,9 +46,7 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
     final annotatedNode = element.computeNode();
     if (annotatedNode is ClassDeclaration) {
       try {
-        final ignore =
-            '// ignore_for_file: private_collision_in_mixin_application\n';
-        return '$ignore${_generateClass(annotatedNode)}';
+        return _generateClass(annotatedNode);
       } catch (e, stackTrace) {
         print('Failure generating class for ${element.library}! '
             '\n $e \n $stackTrace');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pageloader
 
-version: 3.0.0-beta
+version: 3.0.0-beta.1
 
 authors:
   - Marc Fisher II (emeritus) <fisherii@google.com>
@@ -18,15 +18,15 @@ environment:
 
 dependencies:
   build: ^0.12.7
+  build_config: ^0.3.1
   built_value: ^5.1.0
   matcher: ^0.12.0+1
   quiver: ^0.29.0
-  source_gen: ^0.8.0
+  source_gen: ^0.9.0
   webdriver: ^2.0.0-beta+1
 
 dev_dependencies:
-  build_config: ^0.3.1
   build_runner: ^0.9.1
-  built_value_generator: ^5.5.3
+  built_value_generator: ^6.0.0
   path: ^1.3.6
   test: ^1.2.0

--- a/test/examples/correct/class_checks.g.dart
+++ b/test/examples/correct/class_checks.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'class_checks.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'class_checks.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $ClassChecks extends ClassChecks with $$ClassChecks {
   PageLoaderElement $__root__;
   $ClassChecks.create(PageLoaderElement currentContext)
@@ -35,7 +34,6 @@ class $$ClassChecks {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $EnsureTagChecks extends EnsureTagChecks with $$EnsureTagChecks {
   PageLoaderElement $__root__;
   $EnsureTagChecks.create(PageLoaderElement currentContext)
@@ -62,7 +60,6 @@ class $$EnsureTagChecks {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $ClassChecksUsingMixin extends ClassChecksUsingMixin
     with $$ChecksMixin, $$ClassChecksUsingMixin {
   PageLoaderElement $__root__;
@@ -78,7 +75,6 @@ class $$ClassChecksUsingMixin {
   PageLoaderElement get $root => $__root__;
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $EnsureTagChecksUsingMixin extends EnsureTagChecksUsingMixin
     with $$ChecksMixin, $$EnsureTagChecksUsingMixin {
   PageLoaderElement $__root__;
@@ -94,8 +90,6 @@ class $$EnsureTagChecksUsingMixin {
   PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
-
-// ignore_for_file: private_collision_in_mixin_application
 
 class $$ChecksMixin {
   PageLoaderElement $__root__;

--- a/test/examples/correct/empty.g.dart
+++ b/test/examples/correct/empty.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'empty.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'empty.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $Empty extends Empty with $$Empty {
   PageLoaderElement $__root__;
   $Empty.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -22,8 +21,6 @@ class $$Empty {
   PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
-
-// ignore_for_file: private_collision_in_mixin_application
 
 class $$EmptyMixin {
   PageLoaderElement $__root__;

--- a/test/examples/correct/finders.g.dart
+++ b/test/examples/correct/finders.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'finders.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'finders.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $Finders extends Finders with $$Finders {
   PageLoaderElement $__root__;
   $Finders.create(PageLoaderElement currentContext)
@@ -83,7 +82,6 @@ class $$Finders {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $CheckTagPO extends CheckTagPO with $$CheckTagPO {
   PageLoaderElement $__root__;
   $CheckTagPO.create(PageLoaderElement currentContext)
@@ -119,7 +117,6 @@ class $$CheckTagPO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $FindersUsingMixin extends FindersUsingMixin
     with $$FindersMixin, $$FindersUsingMixin {
   PageLoaderElement $__root__;
@@ -134,8 +131,6 @@ class $$FindersUsingMixin {
   PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
-
-// ignore_for_file: private_collision_in_mixin_application
 
 class $$FindersMixin {
   PageLoaderElement $__root__;

--- a/test/examples/correct/generics.g.dart
+++ b/test/examples/correct/generics.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'generics.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'generics.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $Generics<T> extends Generics<T> with $$Generics<T> {
   PageLoaderElement $__root__;
   $Generics.create(PageLoaderElement currentContext)
@@ -45,7 +44,6 @@ class $$Generics<T> {
   PageLoaderElement get $root => $__root__;
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $CheckedGenerics<T> extends CheckedGenerics<T> with $$CheckedGenerics<T> {
   PageLoaderElement $__root__;
   $CheckedGenerics.create(PageLoaderElement currentContext)
@@ -70,7 +68,6 @@ class $$CheckedGenerics<T> {
   PageLoaderElement get $root => $__root__;
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $GenericPair<T, V> extends GenericPair<T, V> with $$GenericPair<T, V> {
   PageLoaderElement $__root__;
   $GenericPair.create(PageLoaderElement currentContext)
@@ -95,7 +92,6 @@ class $$GenericPair<T, V> {
   PageLoaderElement get $root => $__root__;
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $RootPo<T> extends RootPo<T> with $$RootPo<T> {
   PageLoaderElement $__root__;
   $RootPo.create(PageLoaderElement currentContext)
@@ -160,7 +156,6 @@ class $$RootPo<T> {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $GenericsUsingMixin<T> extends GenericsUsingMixin<T>
     with $$GenericsMixin<T>, $$GenericsUsingMixin<T> {
   PageLoaderElement $__root__;
@@ -176,15 +171,12 @@ class $$GenericsUsingMixin<T> {
   PageLoaderElement get $root => $__root__;
 }
 
-// ignore_for_file: private_collision_in_mixin_application
-
 class $$GenericsMixin<T> {
   PageLoaderElement $__root__;
   PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $GenericPairUsingMixin<T, V> extends GenericPairUsingMixin<T, V>
     with $$GenericPairMixin<T, V>, $$GenericPairUsingMixin<T, V> {
   PageLoaderElement $__root__;
@@ -200,15 +192,12 @@ class $$GenericPairUsingMixin<T, V> {
   PageLoaderElement get $root => $__root__;
 }
 
-// ignore_for_file: private_collision_in_mixin_application
-
 class $$GenericPairMixin<T, V> {
   PageLoaderElement $__root__;
   PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $RootPoUsingMixin<T> extends RootPoUsingMixin<T>
     with $$RootPoMixin<T>, $$RootPoUsingMixin<T> {
   PageLoaderElement $__root__;
@@ -223,8 +212,6 @@ class $$RootPoUsingMixin<T> {
   PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
-
-// ignore_for_file: private_collision_in_mixin_application
 
 class $$RootPoMixin<T> {
   PageLoaderElement $__root__;

--- a/test/examples/correct/iterables.g.dart
+++ b/test/examples/correct/iterables.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'iterables.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'iterables.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $Iterables extends Iterables with $$Iterables {
   PageLoaderElement $__root__;
   $Iterables.create(PageLoaderElement currentContext)
@@ -62,7 +61,6 @@ class $$Iterables {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $InnerObject extends InnerObject with $$InnerObject {
   PageLoaderElement $__root__;
   $InnerObject.create(PageLoaderElement currentContext)
@@ -114,7 +112,6 @@ class $$InnerObject {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $IterablesUsingMixin extends IterablesUsingMixin
     with $$IterablesMixin, $$IterablesUsingMixin {
   PageLoaderElement $__root__;
@@ -129,8 +126,6 @@ class $$IterablesUsingMixin {
   PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
-
-// ignore_for_file: private_collision_in_mixin_application
 
 class $$IterablesMixin {
   PageLoaderElement $__root__;
@@ -176,7 +171,6 @@ class $$IterablesMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $InnerObjectUsingMixin extends InnerObjectUsingMixin
     with $$InnerObjectMixin, $$InnerObjectUsingMixin {
   PageLoaderElement $__root__;
@@ -191,8 +185,6 @@ class $$InnerObjectUsingMixin {
   PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
-
-// ignore_for_file: private_collision_in_mixin_application
 
 class $$InnerObjectMixin {
   PageLoaderElement $__root__;

--- a/test/examples/correct/list.g.dart
+++ b/test/examples/correct/list.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'list.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'list.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $Lists extends Lists with $$Lists {
   PageLoaderElement $__root__;
   $Lists.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -100,7 +99,6 @@ class $$Lists {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $InnerListObject extends InnerListObject with $$InnerListObject {
   PageLoaderElement $__root__;
   $InnerListObject.create(PageLoaderElement currentContext)
@@ -139,7 +137,6 @@ class $$InnerListObject {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $ListsUsingMixin extends ListsUsingMixin
     with $$ListsMixin, $$ListsUsingMixin {
   PageLoaderElement $__root__;
@@ -154,8 +151,6 @@ class $$ListsUsingMixin {
   PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
-
-// ignore_for_file: private_collision_in_mixin_application
 
 class $$ListsMixin {
   PageLoaderElement $__root__;
@@ -240,7 +235,6 @@ class $$ListsMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $InnerListObjectUsingMixin extends InnerListObjectUsingMixin
     with $$InnerListObjectMixin, $$InnerListObjectUsingMixin {
   PageLoaderElement $__root__;
@@ -255,8 +249,6 @@ class $$InnerListObjectUsingMixin {
   PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
-
-// ignore_for_file: private_collision_in_mixin_application
 
 class $$InnerListObjectMixin {
   PageLoaderElement $__root__;

--- a/test/examples/correct/mouse.g.dart
+++ b/test/examples/correct/mouse.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'mouse.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'mouse.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $MouseObject extends MouseObject with $$MouseObject {
   PageLoaderElement $__root__;
   $MouseObject.create(PageLoaderElement currentContext)
@@ -35,7 +34,6 @@ class $$MouseObject {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $MouseObjectUsingMixin extends MouseObjectUsingMixin
     with $$MouseObjectMixin, $$MouseObjectUsingMixin {
   PageLoaderElement $__root__;
@@ -50,8 +48,6 @@ class $$MouseObjectUsingMixin {
   PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
-
-// ignore_for_file: private_collision_in_mixin_application
 
 class $$MouseObjectMixin {
   PageLoaderElement $__root__;

--- a/test/examples/correct/multiple_in_file.g.dart
+++ b/test/examples/correct/multiple_in_file.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'multiple_in_file.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'multiple_in_file.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $A extends A with $$A {
   PageLoaderElement $__root__;
   $A.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -35,7 +34,6 @@ class $$A {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $B extends B with $$B {
   PageLoaderElement $__root__;
   $B.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -60,7 +58,6 @@ class $$B {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $C extends C with $$C {
   PageLoaderElement $__root__;
   $C.create(PageLoaderElement currentContext) : $__root__ = currentContext {

--- a/test/examples/correct/nested.g.dart
+++ b/test/examples/correct/nested.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'nested.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'nested.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $Nested extends Nested with $$Nested {
   PageLoaderElement $__root__;
   $Nested.create(PageLoaderElement currentContext)
@@ -36,7 +35,6 @@ class $$Nested {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $NestedUsingMixin extends NestedUsingMixin
     with $$NestedMixin, $$NestedUsingMixin {
   PageLoaderElement $__root__;
@@ -51,8 +49,6 @@ class $$NestedUsingMixin {
   PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
-
-// ignore_for_file: private_collision_in_mixin_application
 
 class $$NestedMixin {
   PageLoaderElement $__root__;

--- a/test/examples/correct/parameters.g.dart
+++ b/test/examples/correct/parameters.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'parameters.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'parameters.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $Parameters extends Parameters with $$Parameters {
   PageLoaderElement $__root__;
   $Parameters.create(PageLoaderElement currentContext)
@@ -77,7 +76,6 @@ class $$Parameters {
   PageLoaderElement get $root => $__root__;
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $ParametersUsingMixin extends ParametersUsingMixin
     with $$ParametersMixin, $$ParametersUsingMixin {
   PageLoaderElement $__root__;
@@ -92,8 +90,6 @@ class $$ParametersUsingMixin {
   PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
-
-// ignore_for_file: private_collision_in_mixin_application
 
 class $$ParametersMixin {
   PageLoaderElement $__root__;

--- a/test/examples/correct/root.g.dart
+++ b/test/examples/correct/root.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'root.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'root.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $ParentRoot extends ParentRoot with $$ParentRoot {
   PageLoaderElement $__root__;
   $ParentRoot.create(PageLoaderElement currentContext)
@@ -35,7 +34,6 @@ class $$ParentRoot {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $Root extends Root with $$Root {
   PageLoaderElement $__root__;
   $Root.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -72,7 +70,6 @@ class $$Root {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $ParentRootUsingMixin extends ParentRootUsingMixin
     with $$ParentRootMixin, $$ParentRootUsingMixin {
   PageLoaderElement $__root__;
@@ -87,8 +84,6 @@ class $$ParentRootUsingMixin {
   PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
-
-// ignore_for_file: private_collision_in_mixin_application
 
 class $$ParentRootMixin {
   PageLoaderElement $__root__;
@@ -107,7 +102,6 @@ class $$ParentRootMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $RootUsingMixin extends RootUsingMixin
     with $$RootMixin, $$RootUsingMixin {
   PageLoaderElement $__root__;
@@ -122,8 +116,6 @@ class $$RootUsingMixin {
   PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
-
-// ignore_for_file: private_collision_in_mixin_application
 
 class $$RootMixin {
   PageLoaderElement $__root__;

--- a/test/examples/correct/unannotated.g.dart
+++ b/test/examples/correct/unannotated.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'unannotated.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'unannotated.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $Unannotated extends Unannotated with $$Unannotated {
   PageLoaderElement $__root__;
   $Unannotated.create(PageLoaderElement currentContext)
@@ -111,7 +110,6 @@ class $$Unannotated {
   PageLoaderElement get $root => $__root__;
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $UnannotatedUsingMixin extends UnannotatedUsingMixin
     with $$UnannotatedMixin, $$UnannotatedUsingMixin {
   PageLoaderElement $__root__;
@@ -126,8 +124,6 @@ class $$UnannotatedUsingMixin {
   PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
-
-// ignore_for_file: private_collision_in_mixin_application
 
 class $$UnannotatedMixin {
   PageLoaderElement $__root__;

--- a/test/src/annotations.g.dart
+++ b/test/src/annotations.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'annotations.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'annotations.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $BaseObject extends BaseObject with $$BaseObject {
   PageLoaderElement $__root__;
   $BaseObject.create(PageLoaderElement currentContext)
@@ -72,7 +71,6 @@ class $$BaseObject {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $PseudoBaseObject extends PseudoBaseObject with $$PseudoBaseObject {
   PageLoaderElement $__root__;
   $PseudoBaseObject.create(PageLoaderElement currentContext)
@@ -125,7 +123,6 @@ class $$PseudoBaseObject {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $TableForCheckTag extends TableForCheckTag with $$TableForCheckTag {
   PageLoaderElement $__root__;
   $TableForCheckTag.create(PageLoaderElement currentContext)
@@ -177,7 +174,6 @@ class $$TableForCheckTag {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $BaseEnsureObject extends BaseEnsureObject with $$BaseEnsureObject {
   PageLoaderElement $__root__;
   $BaseEnsureObject.create(PageLoaderElement currentContext)
@@ -215,7 +211,6 @@ class $$BaseEnsureObject {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $TableForEnsureTag extends TableForEnsureTag with $$TableForEnsureTag {
   PageLoaderElement $__root__;
   $TableForEnsureTag.create(PageLoaderElement currentContext)
@@ -255,7 +250,6 @@ class $$TableForEnsureTag {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $CheckTagFails extends CheckTagFails with $$CheckTagFails {
   PageLoaderElement $__root__;
   $CheckTagFails.create(PageLoaderElement currentContext)
@@ -281,7 +275,6 @@ class $$CheckTagFails {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $EnsureTagFails extends EnsureTagFails with $$EnsureTagFails {
   PageLoaderElement $__root__;
   $EnsureTagFails.create(PageLoaderElement currentContext)
@@ -308,7 +301,6 @@ class $$EnsureTagFails {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $PageForWithAttributeTest extends PageForWithAttributeTest
     with $$PageForWithAttributeTest {
   PageLoaderElement $__root__;
@@ -336,7 +328,6 @@ class $$PageForWithAttributeTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $PageForWithClassTest extends PageForWithClassTest
     with $$PageForWithClassTest {
   PageLoaderElement $__root__;
@@ -364,7 +355,6 @@ class $$PageForWithClassTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $DebugIds extends DebugIds with $$DebugIds {
   PageLoaderElement $__root__;
   $DebugIds.create(PageLoaderElement currentContext)

--- a/test/src/attributes.g.dart
+++ b/test/src/attributes.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'attributes.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'attributes.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $PageForAttributesTests extends PageForAttributesTests
     with $$PageForAttributesTests {
   PageLoaderElement $__root__;

--- a/test/src/basic.g.dart
+++ b/test/src/basic.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'basic.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'basic.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $PageForExistsTest extends PageForExistsTest with $$PageForExistsTest {
   PageLoaderElement $__root__;
   $PageForExistsTest.create(PageLoaderElement currentContext)
@@ -60,7 +59,6 @@ class $$PageForExistsTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $PageForVisibilityTest extends PageForVisibilityTest
     with $$PageForVisibilityTest {
   PageLoaderElement $__root__;
@@ -101,7 +99,6 @@ class $$PageForVisibilityTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $PageForClassAnnotationTest extends PageForClassAnnotationTest
     with $$PageForClassAnnotationTest {
   PageLoaderElement $__root__;
@@ -128,7 +125,6 @@ class $$PageForClassAnnotationTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $PageForPrivateFieldsTest extends PageForPrivateFieldsTest
     with $$PageForPrivateFieldsTest {
   PageLoaderElement $__root__;
@@ -167,7 +163,6 @@ class $$PageForPrivateFieldsTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $PageForFocusTest extends PageForFocusTest with $$PageForFocusTest {
   PageLoaderElement $__root__;
   $PageForFocusTest.create(PageLoaderElement currentContext)
@@ -193,7 +188,6 @@ class $$PageForFocusTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $PageForNbspTest extends PageForNbspTest with $$PageForNbspTest {
   PageLoaderElement $__root__;
   $PageForNbspTest.create(PageLoaderElement currentContext)
@@ -219,7 +213,6 @@ class $$PageForNbspTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $Basic extends Basic with $$Basic {
   PageLoaderElement $__root__;
   $Basic.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -245,7 +238,6 @@ class $$Basic {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $OuterNested extends OuterNested with $$OuterNested {
   PageLoaderElement $__root__;
   $OuterNested.create(PageLoaderElement currentContext)
@@ -272,7 +264,6 @@ class $$OuterNested {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $DebugId extends DebugId with $$DebugId {
   PageLoaderElement $__root__;
   $DebugId.create(PageLoaderElement currentContext)
@@ -298,7 +289,6 @@ class $$DebugId {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $Display extends Display with $$Display {
   PageLoaderElement $__root__;
   $Display.create(PageLoaderElement currentContext)

--- a/test/src/cache_invalidation.g.dart
+++ b/test/src/cache_invalidation.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'cache_invalidation.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'cache_invalidation.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $CacheInvalidation extends CacheInvalidation with $$CacheInvalidation {
   PageLoaderElement $__root__;
   $CacheInvalidation.create(PageLoaderElement currentContext)
@@ -47,7 +46,6 @@ class $$CacheInvalidation {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $_Nested extends _Nested with $$_Nested {
   PageLoaderElement $__root__;
   $_Nested.create(PageLoaderElement currentContext)

--- a/test/src/constructors.g.dart
+++ b/test/src/constructors.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'constructors.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'constructors.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $BasePO extends BasePO with $$BasePO {
   PageLoaderElement $__root__;
   $BasePO.create(PageLoaderElement currentContext)
@@ -42,7 +41,6 @@ class $$BasePO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $BCustomTagPO extends BCustomTagPO with $$BCustomTagPO {
   PageLoaderElement $__root__;
   $BCustomTagPO.create(PageLoaderElement currentContext)
@@ -125,7 +123,6 @@ class $$BCustomTagPO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $CCustomTagPO extends CCustomTagPO with $$CCustomTagPO {
   PageLoaderElement $__root__;
   $CCustomTagPO.create(PageLoaderElement currentContext)
@@ -164,7 +161,6 @@ class $$CCustomTagPO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $NoLookupPO extends NoLookupPO with $$NoLookupPO {
   PageLoaderElement $__root__;
   $NoLookupPO.create(PageLoaderElement currentContext)

--- a/test/src/generics.g.dart
+++ b/test/src/generics.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'generics.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'generics.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $Generics<T> extends Generics<T> with $$Generics<T> {
   PageLoaderElement $__root__;
   $Generics.create(PageLoaderElement currentContext)
@@ -34,7 +33,6 @@ class $$Generics<T> {
   PageLoaderElement get $root => $__root__;
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $RootPo<T> extends RootPo<T> with $$RootPo<T> {
   PageLoaderElement $__root__;
   $RootPo.create(PageLoaderElement currentContext)

--- a/test/src/list.g.dart
+++ b/test/src/list.g.dart
@@ -66,7 +66,6 @@ class $$Lists {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $RowPO extends RowPO with $$RowPO {
   PageLoaderElement $__root__;
   $RowPO.create(PageLoaderElement currentContext) : $__root__ = currentContext {

--- a/test/src/list.g.dart
+++ b/test/src/list.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'list.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'list.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $Lists extends Lists with $$Lists {
   PageLoaderElement $__root__;
   $Lists.create(PageLoaderElement currentContext) : $__root__ = currentContext {

--- a/test/src/mouse.g.dart
+++ b/test/src/mouse.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'mouse.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'mouse.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $PageForMouseTest extends PageForMouseTest with $$PageForMouseTest {
   PageLoaderElement $__root__;
   $PageForMouseTest.create(PageLoaderElement currentContext)

--- a/test/src/properties.g.dart
+++ b/test/src/properties.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'properties.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'properties.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $PageForPropertiesTests extends PageForPropertiesTests
     with $$PageForPropertiesTests {
   PageLoaderElement $__root__;

--- a/test/src/shared_list_page_objects.g.dart
+++ b/test/src/shared_list_page_objects.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'shared_list_page_objects.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'shared_list_page_objects.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $PageForSimpleTest extends PageForSimpleTest with $$PageForSimpleTest {
   PageLoaderElement $__root__;
   $PageForSimpleTest.create(PageLoaderElement currentContext)
@@ -47,7 +46,6 @@ class $$PageForSimpleTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $Table extends Table with $$Table {
   PageLoaderElement $__root__;
   $Table.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -98,7 +96,6 @@ class $$Table {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $Row extends Row with $$Row {
   PageLoaderElement $__root__;
   $Row.create(PageLoaderElement currentContext) : $__root__ = currentContext {

--- a/test/src/shared_page_objects.g.dart
+++ b/test/src/shared_page_objects.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'shared_page_objects.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'shared_page_objects.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $PageForSimpleTest extends PageForSimpleTest with $$PageForSimpleTest {
   PageLoaderElement $__root__;
   $PageForSimpleTest.create(PageLoaderElement currentContext)
@@ -35,7 +34,6 @@ class $$PageForSimpleTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $Table extends Table with $$Table {
   PageLoaderElement $__root__;
   $Table.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -83,7 +81,6 @@ class $$Table {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $Row extends Row with $$Row {
   PageLoaderElement $__root__;
   $Row.create(PageLoaderElement currentContext) : $__root__ = currentContext {

--- a/test/src/typing.g.dart
+++ b/test/src/typing.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'typing.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'typing.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $PageForTextAreaTypingText extends PageForTextAreaTypingText
     with $$PageForTextAreaTypingText {
   PageLoaderElement $__root__;
@@ -36,7 +35,6 @@ class $$PageForTextAreaTypingText {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 class $PageForTypingTests extends PageForTypingTests with $$PageForTypingTests {
   PageLoaderElement $__root__;
   $PageForTypingTests.create(PageLoaderElement currentContext)

--- a/test/src/webdriver_only.g.dart
+++ b/test/src/webdriver_only.g.dart
@@ -1,8 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
-
 part of 'webdriver_only.dart';
 
 // **************************************************************************
@@ -10,6 +7,8 @@ part of 'webdriver_only.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
 class $WebDriverOnly extends WebDriverOnly with $$WebDriverOnly {
   PageLoaderElement $__root__;
   $WebDriverOnly.create(PageLoaderElement currentContext)


### PR DESCRIPTION
pageloader can now be combined with other builders that want to output
to `.g.dart` part files.

- Upgrade to the latest buit_value_generator for compatibility.
- Change the output extension to `.pageloader.g.part` following the new
  `source_gen` convention and apply the combining builder to get the
  `.g.dart`.
- Remove the header option since it is no longer supported and move the
  extra ignores into the generator itself.
- Override the `generate` method to prepend the ignores once instead of
  once per annotated element.
- Regenerate all files.
- Move `build_config` to normal dependencies since it is used to parse
  this package's `build.yaml` when used transitively.