### PR TITLE
Sync up with latest PageLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ To construct a PageObject, use this `create` constructor on either
 import 'package:pageloader/html.dart';
 
 Element myElement = ...;
-final context = new HtmlPageLoaderElement.createFromElement(myElement);
-final myPO = new MyPO.create(context);
+final context = HtmlPageLoaderElement.createFromElement(myElement);
+final myPO = MyPO.create(context);
 ```
 
 `createFromElement` has an additional named argument `SyncFn externalSyncFn`.
@@ -88,12 +88,12 @@ into effect. By default, this is a no-op function.
 An example of a custom sync function:
 
 ```dart
-new HtmlPageLoaderElement.createFromElement(myElement,
+HtmlPageLoaderElement.createFromElement(myElement,
         externalSyncFn: (Future action()) async {
       await action();
       // Wait longer than normal
       for (var i = 0; i < 1000; i++) {
-        await new Future.value();
+        await Future.value();
       }
     });
 ```
@@ -111,13 +111,13 @@ import 'package:webdriver/sync_io.dart';
 
 String pagePath = ...; // Page uri path
 Webdriver driver = ...; // Refer to Webdriver package documentation
-WebDriverPageUtils loader = new WebDriverPageUtils(driver);
+WebDriverPageUtils loader = WebDriverPageUtils(driver);
 driver.get(pagePath);
 
 WebDriverPageLoaderElement context = loader.root;
 WebDriverMouse get mouse = loader.mouse;
 
-final myPO = new MyPO.create(context);
+final myPO = MyPO.create(context);
 
 // ...run tests...
 
@@ -134,7 +134,7 @@ Lazy Loading
 Starting from version 3, all elements are lazy.
 
 ```dart
-final myPO = new MyPO.create(pageLoaderElementContext);
+final myPO = MyPO.create(pageLoaderElementContext);
 ```
 
 Nothing happens with the browser at this point. You need to either
@@ -188,7 +188,7 @@ For PageObjects, use provided matchers:
 ```dart
 import 'package:pageloader/testing.dart';
 
-SomePO somePO = new SomePO.create(context);
+SomePO somePO = SomePO.create(context);
 expect(somePO, exists);
 ```
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -56,6 +56,8 @@ linter:
     - type_init_formals
     - unawaited_futures
     - unnecessary_brace_in_string_interps
+    - unnecessary_const
     - unnecessary_getters_setters
+    - unnecessary_new
     - unrelated_type_equality_checks
     - valid_regexps

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -32,15 +32,15 @@ import 'src/generators/pageobject_generator.dart';
 Builder pageloaderBuilder(BuilderOptions options) {
   // Paranoid copy of options.config - don't assume it's mutable or needed
   // elsewhere.
-  final optionsMap = new Map<String, dynamic>.from(options.config);
+  final optionsMap = Map<String, dynamic>.from(options.config);
 
-  final builder = new PartBuilder([
-    new PageObjectGenerator(),
+  final builder = PartBuilder([
+    PageObjectGenerator(),
   ], header: optionsMap.remove('header') as String);
 
   if (optionsMap.isNotEmpty) {
     if (log == null) {
-      throw new StateError('Upgrade `build_runner` to at least 0.8.2.');
+      throw StateError('Upgrade `build_runner` to at least 0.8.2.');
     } else {
       log.warning('These options were ignored: `$optionsMap`.');
     }

--- a/lib/pageloader.dart
+++ b/lib/pageloader.dart
@@ -19,5 +19,6 @@ export 'src/api/iterable_interfaces.dart';
 export 'src/api/page_loader_element_interface.dart';
 export 'src/api/page_loader_listener.dart';
 export 'src/api/page_loader_mouse_interface.dart';
+export 'src/api/page_loader_source_interface.dart';
 export 'src/api/page_object_list_interface.dart';
 export 'src/api/page_utils_interface.dart';

--- a/lib/src/api/annotation_interfaces.dart
+++ b/lib/src/api/annotation_interfaces.dart
@@ -16,7 +16,7 @@ library pageloader.api.annotation_interfaces;
 
 import 'page_loader_element_interface.dart';
 
-/// Finds all matching elements within the parent context.
+/// Finds all matching elements STRICTLY underneath the parent context.
 ///
 /// Can only be used on an abstract getter method.
 abstract class Finder {}

--- a/lib/src/api/annotations.dart
+++ b/lib/src/api/annotations.dart
@@ -25,7 +25,7 @@ export 'page_object_annotation.dart';
 ///
 /// Must be applied to a [PageLoaderElement] getter. No other annotations may be
 /// used.
-const root = const _Root();
+const root = _Root();
 
 class _Root {
   const _Root();
@@ -38,7 +38,7 @@ class _Root {
 ///
 /// Must be applied to a [PageLoaderMouse] getter. No other annotations may be
 /// used.
-const Mouse = const _Mouse();
+const Mouse = _Mouse();
 
 class _Mouse {
   const _Mouse();

--- a/lib/src/api/iterable_interfaces.dart
+++ b/lib/src/api/iterable_interfaces.dart
@@ -48,7 +48,7 @@ class PageObjectIterable<E> {
 
   /// Creates a [PageObjectIterator] based on the underlying
   /// [PageElementIterable].
-  Future<Iterator<E>> get iterator async => new PageObjectIterator<E>(
+  Future<Iterator<E>> get iterator async => PageObjectIterator<E>(
       await _elementIterable.iterator, _pageObjectConstructor);
 
   /// Gets the current length of the underlying [PageElementIterable].

--- a/lib/src/api/page_loader_element_interface.dart
+++ b/lib/src/api/page_loader_element_interface.dart
@@ -19,11 +19,12 @@ import 'dart:math';
 import 'annotation_interfaces.dart';
 import 'iterable_interfaces.dart';
 import 'page_loader_listener.dart';
+import 'page_loader_source_interface.dart';
 import 'page_utils_interface.dart';
 
 /// Base class for interacting with raw DOM elements, e.g. buttons, input
 /// fields, etc.
-abstract class PageLoaderElement {
+abstract class PageLoaderElement extends PageLoaderSource {
   /// Creates a new element based on the current context plus the passed
   /// [Finder], [Filter]s, and [Checker]s.
   PageLoaderElement createElement(
@@ -137,6 +138,11 @@ abstract class PageLoaderElement {
 
   /// Clicks on the element.
   Future<void> click();
+
+  /// Clicks outside of the current element.
+  ///
+  /// If the current element does not exist or is not displayed, do nothing.
+  Future<void> clickOutside();
 
   /// Types [keys] into this element, if possible (e.g. for an input element).
   ///

--- a/lib/src/api/page_loader_mouse_interface.dart
+++ b/lib/src/api/page_loader_mouse_interface.dart
@@ -14,6 +14,7 @@
 library pageloader.api.page_loader_mouse_interface;
 
 import 'dart:async';
+import 'dart:core';
 
 import 'package:webdriver/sync_core.dart' show MouseButton;
 
@@ -35,10 +36,25 @@ abstract class PageLoaderMouse {
   /// under the current mouse location.
   Future<void> up(MouseButton button, {PageLoaderElement eventTarget});
 
-  /// Move the mouse to a location relative to [element]. If [eventTarget] is
-  /// specified, PageLoader will attempt to fire the corresponding mouse events
-  /// on that target, otherwise it will fire the events on the target that is
-  /// under the current mouse location.
-  Future<void> moveTo(PageLoaderElement element, int xOffset, int yOffset,
-      {PageLoaderElement eventTarget});
+  /// Move the mouse from previous location to a location relative to [element],
+  /// offset by [xOffset] and [yOffset].
+  ///
+  /// If [xOffset] and [yOffset] are both null, automatically moves the mouse
+  /// to the center of [element].
+  ///
+  /// The optional named parameters have no impact when used with Webdriver
+  /// implementation.
+  ///
+  /// Otherwise, mouse events are sent along the mouse path
+  /// every [stepPixels] over [duration] milliseconds. If any of the
+  /// [dispatchTo] land on these intervals, mouse events are also sent
+  /// to that element. If [stepPixels] is not provided, the mouse movement
+  /// instantaneously moves from its current position to the final position
+  /// with no intermediate steps. If provided, [stepPixels] must be a value
+  /// greater than zero.
+  // TODO: Determine consistent behavior when element is null and
+  // how off-screen events should be handled.
+  Future<void> moveTo(
+      covariant PageLoaderElement element, int xOffset, int yOffset,
+      {List<PageLoaderElement> dispatchTo, int stepPixels, Duration duration});
 }

--- a/lib/src/api/page_loader_source_interface.dart
+++ b/lib/src/api/page_loader_source_interface.dart
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All rights reserved.
+// Copyright 2018 Google Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,17 +11,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library pageloader.api.page_loader_interface;
+library pageloader3.api.page_loader_source_interface;
 
 import 'page_loader_element_interface.dart';
-import 'page_loader_mouse_interface.dart';
-import 'page_loader_source_interface.dart';
 
-/// Convenience methods that vary based on environment.
-abstract class PageUtils extends PageLoaderSource {
-  /// Gets the current root element for the DOM. Used to create page objects.
-  PageLoaderElement get root;
-
-  /// Gets the mouse.
-  PageLoaderMouse get mouse;
+/// Base class for Pageloader entities that behave as the source for other
+/// [PageLoaderElement]s.
+abstract class PageLoaderSource {
+  /// Finds [PageLoaderElement] from this source by [tag].
+  ///
+  /// If used with [PageUtils], finds the element representing [tag]
+  /// found from the document root.
+  /// If used with [PageLoaderElement], finds the element representing [tag]
+  /// found from the [PageLoaderElement] as root.
+  PageLoaderElement byTag(String tag);
 }

--- a/lib/src/api/page_object_list_interface.dart
+++ b/lib/src/api/page_object_list_interface.dart
@@ -38,11 +38,11 @@ class PageObjectList<E> extends ListBase<E> {
   int get length => _elementList.length;
 
   @override
-  set length(int newLength) => throw new PageLoaderException(
+  set length(int newLength) => throw PageLoaderException(
       'Cannot modify PageObjectList (call to length setter)');
 
   @override
-  void operator []=(int index, E value) => throw new PageLoaderException(
+  void operator []=(int index, E value) => throw PageLoaderException(
       'Cannot modify PageObjectList (call to operator[]=)');
 
   @override

--- a/lib/src/core/core.dart
+++ b/lib/src/core/core.dart
@@ -35,7 +35,7 @@ List<PageLoaderElement> applyFiltersAndChecks(List<PageLoaderElement> elements,
   for (final element in filteredElements) {
     for (final check in checkers) {
       if (!check.check(element)) {
-        throw new PageLoaderException.withContext(
+        throw PageLoaderException.withContext(
             'Failed check: ${check.toString()}', element);
       }
     }

--- a/lib/src/debug/performance/timer_duration.dart
+++ b/lib/src/debug/performance/timer_duration.dart
@@ -13,7 +13,7 @@
 
 import 'event.dart';
 
-final _defaultTimerConfiguration = new CollectingTimerConfiguration();
+final _defaultTimerConfiguration = CollectingTimerConfiguration();
 
 typedef void Collector(List<DurationEvent> events);
 
@@ -24,13 +24,13 @@ class CollectingTimerFactory {
 
   CollectingTimer create(String timerName,
       {CollectingTimerConfiguration timerConfiguration}) {
-    final configuration = new CollectingTimerConfiguration.from(
+    final configuration = CollectingTimerConfiguration.from(
         timerConfiguration ?? _defaultTimerConfiguration)
       ..timerName = timerName;
-    return new CollectingTimer(_collect, configuration);
+    return CollectingTimer(_collect, configuration);
   }
 
-  TraceEvent serialize() => new TraceEvent()..traceEvents = _collectedEvents;
+  TraceEvent serialize() => TraceEvent()..traceEvents = _collectedEvents;
 
   void _collect(List<DurationEvent> events) {
     _collectedEvents.addAll(events);
@@ -50,7 +50,7 @@ class CollectingTimerConfiguration {
 
   factory CollectingTimerConfiguration.from(
       CollectingTimerConfiguration other) {
-    return new CollectingTimerConfiguration()
+    return CollectingTimerConfiguration()
       ..timerName = other.timerName
       ..pid = other.pid
       ..tid = other.tid;
@@ -62,7 +62,7 @@ class CollectingTimerConfiguration {
 /// On [stop], the event is collected back to the main factory.
 class CollectingTimer {
   final CollectingTimerConfiguration configuration;
-  final Stopwatch _stopwatch = new Stopwatch();
+  final Stopwatch _stopwatch = Stopwatch();
   final Collector _collector;
   bool _isRunning = false;
   DateTime _startDuration;
@@ -72,7 +72,7 @@ class CollectingTimer {
   void start() {
     assert(!_isRunning);
     _isRunning = true;
-    _startDuration = new DateTime.now();
+    _startDuration = DateTime.now();
     _stopwatch.reset();
     _stopwatch.start();
   }
@@ -82,20 +82,20 @@ class CollectingTimer {
     _isRunning = false;
     _stopwatch.stop();
 
-    final startEvent = new DurationEvent()
+    final startEvent = DurationEvent()
       ..name = configuration.timerName
       ..pid = configuration.pid
       ..tid = configuration.tid
       ..phase = DurationEventPhase.begin
       ..ts = _startDuration;
 
-    final endEvent = new DurationEvent()
+    final endEvent = DurationEvent()
       ..name = configuration.timerName
       ..pid = configuration.pid
       ..tid = configuration.tid
       ..phase = DurationEventPhase.end
       ..ts = _startDuration
-          .add(new Duration(microseconds: _stopwatch.elapsedMicroseconds));
+          .add(Duration(microseconds: _stopwatch.elapsedMicroseconds));
 
     _collector([startEvent, endEvent]);
   }

--- a/lib/src/generators/class_checks_collector.dart
+++ b/lib/src/generators/class_checks_collector.dart
@@ -19,7 +19,7 @@ import 'methods/core.dart' as core;
 
 String _generateCheck(Annotation annotation) {
   if (annotation.arguments == null) throw 'bad';
-  return 'new ${annotation.name.toString()}'
+  return '${annotation.name.toString()}'
       '(${annotation.arguments.arguments.join(', ')})';
 }
 

--- a/lib/src/generators/collector_visitor.dart
+++ b/lib/src/generators/collector_visitor.dart
@@ -46,7 +46,14 @@ class CollectorVisitor extends GeneralizingAstVisitor<void> {
 
   /// Write constructor-based contents into string buffer.
   void writeToConstructorBuffer(
-      StringBuffer constructorBuffer, String className) {
+      StringBuffer constructorBuffer, String className, String defaultTag) {
+    if (defaultTag != null) {
+      constructorBuffer.write('static String get tagName => $defaultTag;');
+    } else {
+      constructorBuffer.write("static String get tagName => throw '\"tagName\" "
+          "is not defined by Page Object \"$className\". Requires @CheckTag "
+          "annotation in order for \"tagName\" to be generated.';");
+    }
     final addToConstructor =
         (method) => constructorBuffer.writeln(method.generate(className));
     getters.forEach(addToConstructor);

--- a/lib/src/generators/collector_visitor.dart
+++ b/lib/src/generators/collector_visitor.dart
@@ -77,7 +77,7 @@ class CollectorVisitor extends GeneralizingAstVisitor<void> {
   void visitFieldDeclaration(FieldDeclaration node) {
     final matching = node.metadata.where(isPageloaderAnnotation);
     if (matching.isNotEmpty) {
-      badMethods.add(new InvalidMethodException(
+      badMethods.add(InvalidMethodException(
           node.toSource(),
           'Field declarations should never have PageLoader annotations. '
           '(Did you forget "get" on a PageLoader getter?)'));
@@ -109,7 +109,7 @@ class CollectorVisitor extends GeneralizingAstVisitor<void> {
         unsupportedMethods.add(node.toSource());
       } else if (collected.length > 1) {
         oversupportedMethods
-            .add(new OverSupportedMethod(node.toSource(), collected));
+            .add(OverSupportedMethod(node.toSource(), collected));
       }
     }
   }

--- a/lib/src/generators/methods/annotation_evaluators.dart
+++ b/lib/src/generators/methods/annotation_evaluators.dart
@@ -29,7 +29,7 @@ final String pageLoaderAnnotationInterface =
 
 /// Returns set of AnnotationKinds that match '@root', '@Mouse'.
 Set<AnnotationKind> evaluateAsAtomicAnnotation(Element element) {
-  final returnSet = new Set<AnnotationKind>();
+  final returnSet = Set<AnnotationKind>();
   if (element is PropertyAccessorElement &&
       element.library.name == pageLoaderAnnotations) {
     final result = classNameToAnnotationKind(element.name, isAtomic: true);
@@ -43,7 +43,7 @@ Set<AnnotationKind> evaluateAsAtomicAnnotation(Element element) {
 /// Returns set of AnnotationKinds if the annotation is a subclass of
 /// Finder, Checker, and/or Filter.
 Set<AnnotationKind> evaluateAsInterfaceAnnotation(Element element) {
-  final returnSet = new Set<AnnotationKind>();
+  final returnSet = Set<AnnotationKind>();
   InterfaceType type;
   if (element is PropertyAccessorElement) {
     // Annotation is a top-level variable.
@@ -57,8 +57,8 @@ Set<AnnotationKind> evaluateAsInterfaceAnnotation(Element element) {
   }
 
   if (type != null) {
-    final types = new Queue<InterfaceType>()..add(type);
-    final seenValidAnnotations = new Set<AnnotationKind>();
+    final types = Queue<InterfaceType>()..add(type);
+    final seenValidAnnotations = Set<AnnotationKind>();
     do {
       type = types.removeFirst();
       if (type.element.library.name == pageLoaderAnnotationInterface) {

--- a/lib/src/generators/methods/core.dart
+++ b/lib/src/generators/methods/core.dart
@@ -80,6 +80,19 @@ Optional<Annotation> getEnsureTag(ClassDeclaration declaration) {
       : const Optional.absent();
 }
 
+/// Returns the @CheckTag annotation if it exists.
+Optional<Annotation> getCheckTag(ClassDeclaration declaration) {
+  final checks =
+      declaration.metadata.where((a) => a.name.toSource() == 'CheckTag');
+  if (checks.length > 1) {
+    throw 'Found multiple @CheckTag annotations in class: '
+        '${declaration.toSource()}';
+  }
+  return checks.length == 1
+      ? new Optional.of(checks.single)
+      : const Optional.absent();
+}
+
 /// Returns true if annotation is some type of Pageloader annotation.
 bool isPageloaderAnnotation(Annotation annotation) =>
     getAnnotationKind(annotation).isNotEmpty;

--- a/lib/src/generators/methods/core.dart
+++ b/lib/src/generators/methods/core.dart
@@ -36,7 +36,7 @@ final String pageObjectList = 'PageObjectList';
 
 /// Returns a declaration of a annotation.
 String generateAnnotationDeclaration(Annotation annotation) =>
-    'const ${annotation.name}(${annotation.arguments.arguments.join(", ")})';
+    '${annotation.name}(${annotation.arguments.arguments.join(", ")})';
 
 /// Returns a 'ByTagName' declaration from the 'ByCheckTag' annotation.
 String generateByTagNameFromByCheckTag(InterfaceType node) {
@@ -45,7 +45,7 @@ String generateByTagNameFromByCheckTag(InterfaceType node) {
     throw "'@ByCheckTag' can only be used on getters that return a "
         "PageObject type with the'@CheckTag' annotation.";
   }
-  return "const ByTagName('$defaultTagName')";
+  return "ByTagName('$defaultTagName')";
 }
 
 /// Extracts the tag name from a PageLoader2 class based on `@CheckTag`.
@@ -75,9 +75,7 @@ Optional<Annotation> getEnsureTag(ClassDeclaration declaration) {
     throw 'Found multiple @EnsureTag annotations in class: '
         '${declaration.toSource()}';
   }
-  return ensures.length == 1
-      ? new Optional.of(ensures.single)
-      : const Optional.absent();
+  return ensures.length == 1 ? Optional.of(ensures.single) : Optional.absent();
 }
 
 /// Returns the @CheckTag annotation if it exists.
@@ -88,9 +86,7 @@ Optional<Annotation> getCheckTag(ClassDeclaration declaration) {
     throw 'Found multiple @CheckTag annotations in class: '
         '${declaration.toSource()}';
   }
-  return checks.length == 1
-      ? new Optional.of(checks.single)
-      : const Optional.absent();
+  return checks.length == 1 ? Optional.of(checks.single) : Optional.absent();
 }
 
 /// Returns true if annotation is some type of Pageloader annotation.
@@ -99,7 +95,7 @@ bool isPageloaderAnnotation(Annotation annotation) =>
 
 /// Returns set of all Pageloader annotation the current annotation satisfies.
 Set<AnnotationKind> getAnnotationKind(Annotation annotation) {
-  final returnSet = new Set<AnnotationKind>();
+  final returnSet = Set<AnnotationKind>();
   final element = annotation.element;
   if (element != null) {
     returnSet

--- a/lib/src/generators/methods/core_method_information.dart
+++ b/lib/src/generators/methods/core_method_information.dart
@@ -36,7 +36,7 @@ TypeInformation getTypeInformation(String type) {
   final left = type.indexOf('<');
   final right = type.lastIndexOf('>');
   if (left < 0 || right < 0) {
-    return new TypeInformation((b) => b
+    return TypeInformation((b) => b
       ..type = type
       ..typeArguments = []);
   }
@@ -48,14 +48,14 @@ TypeInformation getTypeInformation(String type) {
       .map((e) => e.trim())
       .map((e) => getTypeInformation(e))
       .toList();
-  return new TypeInformation((b) => b
+  return TypeInformation((b) => b
     ..type = genericType
     ..typeArguments = typeArguments);
 }
 
 TypeInformation extractPageObjectInfo(TypeInformation typeInfo, String source) {
   if (typeInfo.typeArguments.length != 1) {
-    throw new InvalidMethodException(
+    throw InvalidMethodException(
         source,
         'Expected exactly one type argument for ${typeInfo.type}'
         ' in return type. Check the return type, and if needed file a bug.'
@@ -94,7 +94,7 @@ CoreMethodInformation collectCoreMethodInformation(MethodDeclaration node) {
       .map((a) => generateAnnotationDeclaration(a))
       .toList();
   if (finders.length > 1) {
-    throw new InvalidMethodException(
+    throw InvalidMethodException(
         node.toSource(), 'multiple Finders cannot be used for single method');
   }
 
@@ -110,43 +110,43 @@ CoreMethodInformation collectCoreMethodInformation(MethodDeclaration node) {
 
   if (finder == null) {
     if (filters.isNotEmpty) {
-      throw new InvalidMethodException(
+      throw InvalidMethodException(
           node.toSource(), 'found Filters but no Finder');
     }
     if (checkers.isNotEmpty) {
-      throw new InvalidMethodException(
+      throw InvalidMethodException(
           node.toSource(), 'found Checkers but no Finder');
     }
   }
 
   if (isRoot) {
     if (filters.isNotEmpty) {
-      throw new InvalidMethodException(
+      throw InvalidMethodException(
           node.toSource(), 'cannot use Filters with @root');
     }
     if (checkers.isNotEmpty) {
-      throw new InvalidMethodException(
+      throw InvalidMethodException(
           node.toSource(), 'cannot use Checkers with @root');
     }
   }
 
   if (finder != null && isRoot) {
-    throw new InvalidMethodException(
+    throw InvalidMethodException(
         node.toSource(), 'cannot use finder with @root');
   }
 
-  return new CoreMethodInformation((b) => b
+  return CoreMethodInformation((b) => b
     ..name = node.name.toSource()
     ..isGetter = node.isGetter
     ..isAbstract = node.isAbstract
     ..pageObjectType = pageObjectInfo.type
-    ..pageObjectTemplate = new Optional<String>.fromNullable(
+    ..pageObjectTemplate = Optional<String>.fromNullable(
         pageObjectInfo.typeArguments.length == 1
             ? pageObjectInfo.typeArguments.single.type
             : null)
     ..isFuture = isFuture
     ..isList = isList
-    ..finder = new Optional<String>.fromNullable(finder)
+    ..finder = Optional<String>.fromNullable(finder)
     ..filters = filters
     ..checkers = checkers
     ..isMouse = isMouse

--- a/lib/src/generators/methods/getter.dart
+++ b/lib/src/generators/methods/getter.dart
@@ -24,11 +24,11 @@ part 'getter.g.dart';
 /// Returns a [Getter] for a concrete getters, or [absent()] otherwise.
 Optional<Getter> collectUnannotatedGetter(MethodDeclaration node) {
   if (!node.isAbstract && node.isGetter) {
-    return new Optional.of(new Getter((b) => b
+    return Optional.of(Getter((b) => b
       ..returnType = node.returnType.toString()
       ..name = node.name.toString()));
   }
-  return new Optional.absent();
+  return Optional.absent();
 }
 
 /// Generates source for getter.

--- a/lib/src/generators/methods/iterable_finder_method.dart
+++ b/lib/src/generators/methods/iterable_finder_method.dart
@@ -32,7 +32,7 @@ Optional<IterableFinderMethod> collectIterableFinderGetter(
   if (!node.isGetter ||
       !node.isAbstract ||
       !node.returnType.toString().startsWith(pageObjectIterable)) {
-    return new Optional.absent();
+    return Optional.absent();
   }
 
   String finder;
@@ -41,7 +41,7 @@ Optional<IterableFinderMethod> collectIterableFinderGetter(
   for (final annotation in methodAnnotations) {
     if (isPageloaderFinder(annotation)) {
       if (finder != null) {
-        throw new InvalidMethodException(node.toSource(),
+        throw InvalidMethodException(node.toSource(),
             'multiple Finders cannot be used for single method');
       }
       finder = generateAnnotationDeclaration(annotation);
@@ -54,7 +54,7 @@ Optional<IterableFinderMethod> collectIterableFinderGetter(
 
   final typeArguments = getReturnTypeArguments(node.returnType.toString());
   if (typeArguments.length != 1) {
-    throw new InvalidMethodException(node.toSource(),
+    throw InvalidMethodException(node.toSource(),
         'return type should specify exactly one type argument');
   }
 
@@ -66,16 +66,16 @@ Optional<IterableFinderMethod> collectIterableFinderGetter(
 
   if (finder == null) {
     if (filters.isNotEmpty) {
-      throw new InvalidMethodException(
+      throw InvalidMethodException(
           node.toSource(), 'found Filters but no Finder');
     }
     if (checkers.isNotEmpty) {
-      throw new InvalidMethodException(
+      throw InvalidMethodException(
           node.toSource(), 'found Checkers but no Finder');
     }
-    return new Optional.absent();
+    return Optional.absent();
   } else {
-    return new Optional.of(new IterableFinderMethod((b) => b
+    return Optional.of(IterableFinderMethod((b) => b
       ..name = node.name.toString()
       ..iterableTypeArgument = typeArguments[0]
       ..finderDeclaration = finder
@@ -107,14 +107,14 @@ abstract class IterableFinderMethod
       '$root.createIterable($finderDeclaration, $filterDeclarations, $checkerDeclarations)';
 
   String get _createObjectIterable =>
-      'new PageObjectIterable<$iterableTypeArgument>'
+      'PageObjectIterable<$iterableTypeArgument>'
       '($_createElementIterator, $_constructor)';
 
   String get _constructor {
     if (iterableTypeArgument == 'PageLoaderElement') {
       return '(PageLoaderElement e) => e';
     } else {
-      return '(PageLoaderElement e) => new $iterableTypeArgument.create(e)';
+      return '(PageLoaderElement e) => $iterableTypeArgument.create(e)';
     }
   }
 

--- a/lib/src/generators/methods/list_finder_method.dart
+++ b/lib/src/generators/methods/list_finder_method.dart
@@ -32,7 +32,7 @@ Optional<ListFinderMethod> collectListFinderGetter(
   if ((!methodInfo.isAbstract || !methodInfo.isGetter) ||
       !methodInfo.finder.isPresent ||
       !methodInfo.isList) {
-    return new Optional.absent();
+    return Optional.absent();
   }
 
   // Convert 'ByCheckTag' to 'ByTagName' if necessary.
@@ -42,7 +42,7 @@ Optional<ListFinderMethod> collectListFinderGetter(
         getInnerType(node.returnType.type, methodInfo.pageObjectType));
   }
 
-  return new Optional.of(new ListFinderMethod((b) => b
+  return Optional.of(ListFinderMethod((b) => b
     ..name = methodInfo.name
     ..listTypeArgument = methodInfo.pageObjectType
     ..finderDeclaration = finder
@@ -95,7 +95,7 @@ abstract class ListFinderMethodMixin {
       return '(PageLoaderElement e) => e';
     } else {
       return '(PageLoaderElement e) => '
-          'new $listTypeArgument$generic.create(e)';
+          '$listTypeArgument$generic.create(e)';
     }
   }
 
@@ -106,8 +106,7 @@ abstract class ListFinderMethodMixin {
 
   String get pageObjectList => 'PageObjectList<$listTypeArgument$generic>';
 
-  String get createObjectIterable =>
-      'new PageObjectList<$listTypeArgument$generic>'
+  String get createObjectIterable => 'PageObjectList<$listTypeArgument$generic>'
       '($_createElementIterator, $constructor)';
 
   String get _createElementIterator => '$root.createList('

--- a/lib/src/generators/methods/mouse_finder_method.dart
+++ b/lib/src/generators/methods/mouse_finder_method.dart
@@ -29,28 +29,27 @@ part 'mouse_finder_method.g.dart';
 Optional<MouseFinderMethod> collectMouseFinderGetter(
     CoreMethodInformationBase methodInfo) {
   if (!methodInfo.isMouse) {
-    return new Optional.absent();
+    return Optional.absent();
   }
 
   if (!methodInfo.isAbstract || !methodInfo.isGetter) {
-    throw new InvalidMethodException(methodInfo.nodeSource,
+    throw InvalidMethodException(methodInfo.nodeSource,
         '@Mouse annotation must be used with abstract getter');
   }
   if (methodInfo.finder.isPresent) {
-    throw new InvalidMethodException(
+    throw InvalidMethodException(
         methodInfo.nodeSource, 'cannot use Finder with Mouse annotation');
   }
   if (methodInfo.filters.isNotEmpty) {
-    throw new InvalidMethodException(
+    throw InvalidMethodException(
         methodInfo.nodeSource, 'cannot use Filter with Mouse annotation');
   }
   if (methodInfo.checkers.isNotEmpty) {
-    throw new InvalidMethodException(
+    throw InvalidMethodException(
         methodInfo.nodeSource, 'cannot use Checker with Mouse annotation');
   }
 
-  return new Optional.of(
-      new MouseFinderMethod((b) => b..name = methodInfo.name));
+  return Optional.of(MouseFinderMethod((b) => b..name = methodInfo.name));
 }
 
 /// Generation for @Mouse getters.

--- a/lib/src/generators/methods/setter.dart
+++ b/lib/src/generators/methods/setter.dart
@@ -25,12 +25,12 @@ part 'setter.g.dart';
 Optional<Setter> collectUnannotatedSetter(MethodDeclaration node) {
   if (!node.isAbstract && node.isSetter) {
     final param = node.parameters.parameters.first;
-    return new Optional.of(new Setter((b) => b
+    return Optional.of(Setter((b) => b
       ..name = node.name.toString()
       ..setterType = param.element.type.toString()
       ..setterValueName = param.element.name));
   }
-  return new Optional.absent();
+  return Optional.absent();
 }
 
 /// Generates code for normal setters.

--- a/lib/src/generators/methods/single_finder_method.dart
+++ b/lib/src/generators/methods/single_finder_method.dart
@@ -34,7 +34,7 @@ Optional<SingleFinderMethod> collectSingleFinderGetter(
       node.returnType.toString().startsWith('Future<List<') ||
       node.returnType.toString().startsWith('List<') ||
       node.returnType.toString().startsWith('Lazy<List<')) {
-    return new Optional.absent();
+    return Optional.absent();
   }
 
   final finders = methodAnnotations
@@ -42,7 +42,7 @@ Optional<SingleFinderMethod> collectSingleFinderGetter(
       .map((a) => generateAnnotationDeclaration(a))
       .toList();
   if (finders.length > 1) {
-    throw new InvalidMethodException(
+    throw InvalidMethodException(
         node.toSource(), 'multiple Finders cannot be used for single method');
   }
   var finder = finders.length == 1 ? finders.single : null;
@@ -65,7 +65,7 @@ Optional<SingleFinderMethod> collectSingleFinderGetter(
   if (typeArgument.contains('<')) {
     final typeArguments = getReturnTypeArguments(typeArgument);
     if (typeArguments.length != 1) {
-      throw new InvalidMethodException(
+      throw InvalidMethodException(
           node.toSource(), 'only single template arguments are supported');
     }
     templateType = typeArguments[0];
@@ -79,42 +79,42 @@ Optional<SingleFinderMethod> collectSingleFinderGetter(
 
   if (finder == null) {
     if (filters.isNotEmpty) {
-      throw new InvalidMethodException(
+      throw InvalidMethodException(
           node.toSource(), 'found Filters but no Finder');
     }
     if (checkers.isNotEmpty) {
-      throw new InvalidMethodException(
+      throw InvalidMethodException(
           node.toSource(), 'found Checkers but no Finder');
     }
   }
 
   if (isRoot) {
     if (filters.isNotEmpty) {
-      throw new InvalidMethodException(
+      throw InvalidMethodException(
           node.toSource(), 'cannot use Filters with @root');
     }
     if (checkers.isNotEmpty) {
-      throw new InvalidMethodException(
+      throw InvalidMethodException(
           node.toSource(), 'cannot use Checkers with @root');
     }
   }
 
   if (finder != null && isRoot) {
-    throw new InvalidMethodException(
+    throw InvalidMethodException(
         node.toSource(), 'cannot use finder with @root');
   }
 
   if (finder == null && !isRoot) {
-    return new Optional.absent();
+    return Optional.absent();
   }
 
-  return new Optional.of(new SingleFinderMethod((b) => b
+  return Optional.of(SingleFinderMethod((b) => b
     ..name = node.name.toString()
     ..pageObjectType = typeArgument
-    ..finderDeclaration = new Optional.fromNullable(finder)
+    ..finderDeclaration = Optional.fromNullable(finder)
     ..filterDeclarations = '[${filters.join(', ')}]'
     ..checkerDeclarations = '[${checkers.join(', ')}]'
-    ..templateType = new Optional.fromNullable(templateType)
+    ..templateType = Optional.fromNullable(templateType)
     ..isRoot = isRoot));
 }
 
@@ -175,7 +175,7 @@ abstract class SingleFinderMethodMixin {
     if (pageObjectType == 'PageLoaderElement') {
       return 'element';
     } else {
-      return 'new $pageObjectType$template.create(element)';
+      return '$pageObjectType$template.create(element)';
     }
   }
 

--- a/lib/src/generators/methods/unannotated_method.dart
+++ b/lib/src/generators/methods/unannotated_method.dart
@@ -25,14 +25,14 @@ part 'unannotated_method.g.dart';
 /// Currently just a pass through.
 Optional<UnannotatedMethod> collectUnannotatedMethod(MethodDeclaration node) {
   if (node.isAbstract || node.isGetter || node.isSetter || node.isOperator) {
-    return const Optional.absent();
+    return Optional.absent();
   }
 
-  return new Optional.of(new UnannotatedMethod((b) => b
+  return Optional.of(UnannotatedMethod((b) => b
     ..name = node.name.toString()
     ..returnType = node.returnType.toString()
     ..parameters = node.parameters.parameters
-    ..typeParameters = new Optional.fromNullable(node.typeParameters)));
+    ..typeParameters = Optional.fromNullable(node.typeParameters)));
 }
 
 /// Generation for unannotated method.

--- a/lib/src/generators/pageobject_generator.dart
+++ b/lib/src/generators/pageobject_generator.dart
@@ -137,7 +137,7 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
     mixinBuffer.write('''
       class \$\$$signature {
         PageLoaderElement ${core.root};
-        PageLoaderMouse ${core.mouse};
+        PageLoaderMouse ${core.mouse}; // ignore: unused_field
     ''');
 
     // Add generated root accessor to be used in internal code.

--- a/lib/src/generators/pageobject_generator.dart
+++ b/lib/src/generators/pageobject_generator.dart
@@ -50,13 +50,13 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
   }
 
   String _generateClass(ClassDeclaration declaration) {
-    final collectorVisitor = new CollectorVisitor(declaration);
+    final collectorVisitor = CollectorVisitor(declaration);
     declaration.visitChildren(collectorVisitor);
 
     _doErrorHandling(collectorVisitor);
 
-    final constructorBuffer = new StringBuffer();
-    final mixinBuffer = new StringBuffer();
+    final constructorBuffer = StringBuffer();
+    final mixinBuffer = StringBuffer();
     final className = declaration.name.toString();
     final generics = _generateTypeParameters(declaration);
     final genericsArgs = _generateTypeArguments(declaration);
@@ -66,7 +66,7 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
     // Run check to make sure PO is not extending another PO.
     // Only mixins are allowed.
     if (poExtendsAnotherPo(declaration.element)) {
-      throw new Exception('******************\n\n'
+      throw Exception('******************\n\n'
           'Errors detected during code generation:\n\n'
           "PageObject class '${declaration.name.name}' is extending another "
           "PageObject class. PageObjects may not extend other PageObjects; "
@@ -117,7 +117,7 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
             ? getAnnotationSingleArg(ensureTag.value)
             : getAnnotationSingleArg(checkTag.value);
         constructorBuffer
-            .write('new \$$className.create(source.byTag($defaultTag));');
+            .write('\$$className.create(source.byTag($defaultTag));');
       } else {
         constructorBuffer.write('''throw  "'lookup' constructor for class "
         "$className is not generated and can only be used on Page Object "
@@ -182,7 +182,7 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
     if (visitor.badMethods.isNotEmpty ||
         visitor.oversupportedMethods.isNotEmpty ||
         visitor.unsupportedMethods.isNotEmpty) {
-      throw new Exception('******************\n\n'
+      throw Exception('******************\n\n'
           'Errors detected during code generation:\n\n'
           '${errors.join('\n\n-------------------\n')}'
           '\n\n******************');

--- a/lib/src/html/html_iterators.dart
+++ b/lib/src/html/html_iterators.dart
@@ -35,7 +35,7 @@ class HtmlPageElementIterator extends Iterator<HtmlPageLoaderElement> {
     if (_current == -1) {
       return null;
     }
-    return new HtmlPageLoaderElement.createFromElement(_elements[_current],
+    return HtmlPageLoaderElement.createFromElement(_elements[_current],
         externalSyncFn: _syncFn);
   }
 }
@@ -52,12 +52,12 @@ class HtmlPageElementIterable extends PageElementIterable {
 
   @override
   Future<PageLoaderElement> get first async =>
-      new HtmlPageLoaderElement.createFromElement(_drivingElement.elements[0],
+      HtmlPageLoaderElement.createFromElement(_drivingElement.elements[0],
           externalSyncFn: _drivingElement.syncFn);
 
   @override
   Future<Iterator<PageLoaderElement>> get iterator async {
-    return new HtmlPageElementIterator(
+    return HtmlPageElementIterator(
         _drivingElement.syncFn, _drivingElement.elements);
   }
 

--- a/lib/src/html/html_mouse.dart
+++ b/lib/src/html/html_mouse.dart
@@ -13,61 +13,162 @@
 
 import 'dart:async';
 import 'dart:html';
+import 'dart:math';
 
 import 'package:pageloader/pageloader.dart';
 
 import 'html_page_loader_element.dart';
 
-/// Support for mouse in in-browser context by dispatching [MouseEvent] from
-/// the current element or a given event target.
-class HtmlMouse implements PageLoaderMouse {
-  final SyncFn syncFn;
+HtmlMouse _globalMouse;
+SyncFn _cachedSyncFn;
 
-  int _clientX = 0;
-  int _clientY = 0;
+/// Returns the globally used [HtmlMouse] in Html based tests.
+HtmlMouse globalMouse(SyncFn syncFn) {
+  assert(syncFn != null);
+  // [SyncFn] may change based on when this function is called.
+  // If it does change, we need to create a new [HtmlMouse] since this
+  // indicates the scope of the [HtmlMouse] is outdated.
+  if (_cachedSyncFn == null || _cachedSyncFn != syncFn) {
+    _cachedSyncFn = syncFn;
+    _globalMouse = new HtmlMouse(_cachedSyncFn);
+  }
+  return _globalMouse;
+}
+
+/// Support for mouse in in-browser context by dispatching [MouseEvent]s.
+class HtmlMouse implements PageLoaderMouse {
+  // Last known coordination and the [TrackedElement] at that point.
+  var _cachedPoint = new Point<int>(0, 0);
+  TrackedElement _cachedElement;
+  SyncFn syncFn;
+
+  // Elements that are currently being tracked. This is reset whenever [moveTo]
+  // is executed.
+  var _trackedElements = <TrackedElement>[];
+  var _elementToTrackedElement = <Element, TrackedElement>{};
 
   HtmlMouse(this.syncFn);
 
   @override
   Future down(MouseButton button, {PageLoaderElement eventTarget}) =>
-      syncFn(() => _dispatchEvent('mousedown', eventTarget, button));
-
-  @override
-  Future moveTo(PageLoaderElement element, int xOffset, int yOffset,
-          {PageLoaderElement eventTarget}) =>
       syncFn(() async {
-        if (element is HtmlPageLoaderElement) {
-          _clientX = (element.getBoundingClientRect().left + xOffset).ceil();
-          _clientY = (element.getBoundingClientRect().top + yOffset).ceil();
+        if (eventTarget != null) {
+          await moveTo(eventTarget, null, null);
         }
-        return _dispatchEvent('mousemove', eventTarget);
+        return _dispatchEvent('mousedown', eventTarget, button);
       });
 
   @override
-  Future up(MouseButton button, {PageLoaderElement eventTarget}) =>
-      syncFn(() => _dispatchEvent('mouseup', eventTarget, button));
+  Future moveTo(HtmlPageLoaderElement element, int xOffset, int yOffset,
+          {List<PageLoaderElement> dispatchTo = const <PageLoaderElement>[],
+          int stepPixels,
+          Duration duration = Duration.zero}) =>
+      syncFn(() => _moveTo(element, xOffset, yOffset,
+          dispatchTo: dispatchTo, stepPixels: stepPixels, duration: duration));
 
-  int get _pageX => window.pageXOffset + _clientX;
-  int get _pageY => window.pageYOffset + _clientY;
-  int get _borderWidth => (window.outerWidth - window.innerWidth) ~/ 2;
-  int get _screenX => window.screenLeft + _borderWidth + _clientX;
-  int get _screenY =>
-      window.screenTop +
-      window.outerHeight -
-      window.innerHeight -
-      _borderWidth +
-      _clientY;
+  @override
+  Future up(MouseButton button, {PageLoaderElement eventTarget}) =>
+      syncFn(() async {
+        if (eventTarget != null) {
+          await moveTo(eventTarget, null, null);
+        }
+        return _dispatchEvent('mouseup', eventTarget, button);
+      });
+
+  Future _moveTo(HtmlPageLoaderElement element, int xOffset, int yOffset,
+      {List<PageLoaderElement> dispatchTo = const <PageLoaderElement>[],
+      int stepPixels,
+      Duration duration = Duration.zero}) async {
+    if (stepPixels != null) {
+      assert(stepPixels > 0);
+    }
+
+    // Client start point and end point.
+    final startPoint = _cachedPoint;
+    final rect = element.getBoundingClientRect();
+    final center = _centerOfRect(rect);
+
+    xOffset ??= center.x;
+    yOffset ??= center.y;
+
+    final endPoint = new Point<int>(
+        (rect.left + xOffset).ceil(), (rect.top + yOffset).ceil());
+
+    // Calculate steps needed for mouse move event.
+    final distance = startPoint.distanceTo(endPoint).toInt();
+    final steps = stepPixels == null ? 1 : max(distance ~/ stepPixels, 1);
+
+    // Reset and re-calculate the [Element]s that need to be tracked.
+    // Includes:
+    //   [_cachedElement]
+    //   [dispatchTo] as [TrackedElement]s
+    //   All [Elements] as [TrackedElement] at the end point
+    _trackedElements = <TrackedElement>[];
+    _elementToTrackedElement = <Element, TrackedElement>{};
+    if (_cachedElement != null) {
+      _trackedElements.add(_cachedElement);
+      _elementToTrackedElement[_cachedElement.element] = _cachedElement;
+    }
+    for (final dispatchTarget in dispatchTo) {
+      _track((dispatchTarget as HtmlPageLoaderElement).context as Element,
+          includeChildren: true);
+    }
+    final elementAtEnd = _track(
+        document.elementFromPoint(_pageX(endPoint.x), _pageY(endPoint.y)) ??
+            element.context as Element);
+
+    // Send mouse events from start to end over [steps].
+    for (int step = 0; step < steps; step++) {
+      final lastStep = step == (steps - 1);
+      final stepRatio = step / steps;
+
+      final nextPoint = lastStep
+          ? endPoint
+          : _calculateNextPoint(stepRatio, startPoint, endPoint);
+
+      await _sendMouseEvents(nextPoint, isLastStep: lastStep);
+      if (duration != Duration.zero) {
+        await _sleep(duration ~/ steps);
+      }
+    }
+
+    // Finally, set the new [_cachedPoint] and [_cachedElement].
+    _cachedPoint = endPoint;
+    _cachedElement = elementAtEnd;
+  }
+
+  Point<int> _centerOfRect(Rectangle rect) {
+    final x = (rect.width * 0.5).ceil();
+    final y = (rect.height * 0.5).ceil();
+    return new Point(x, y);
+  }
+
+  /// Calculate the next point of the current step based on [stepRatio].
+  Point<int> _calculateNextPoint(
+      double stepRatio, Point<int> startPoint, Point<int> endPoint) {
+    // To ensure correct casting, calculate manually.
+    final x =
+        (startPoint.x + (stepRatio * (endPoint.x - startPoint.x))).toInt();
+    final y =
+        (startPoint.y + (stepRatio * (endPoint.y - startPoint.y))).toInt();
+    return new Point<int>(x, y);
+  }
+
+  // Gets the current, top-most [Element] under mouse. If no element can be
+  // found, returns the document's body [Element].
   Element get _currentElement =>
-      document.elementFromPoint(_pageX, _pageY) ?? document.body;
+      document.elementFromPoint(
+          _pageX(_cachedPoint.x), _pageY(_cachedPoint.y)) ??
+      document.body;
 
   Future _dispatchEvent(String type, HtmlPageLoaderElement eventTarget,
       [MouseButton button = MouseButton.primary]) async {
     final event = new MouseEvent(type,
         button: button.value,
-        clientX: _clientX,
-        clientY: _clientY,
-        screenX: _screenX,
-        screenY: _screenY);
+        clientX: _cachedPoint.x,
+        clientY: _cachedPoint.y,
+        screenX: _screenX(_cachedPoint.x),
+        screenY: _screenY(_cachedPoint.y));
 
     if (eventTarget != null) {
       await _microtask(() => eventTarget.dispatchEvent(event));
@@ -75,8 +176,219 @@ class HtmlMouse implements PageLoaderMouse {
       await _microtask(() => _currentElement.dispatchEvent(event));
     }
   }
+
+  /// Sends the following events, as needed, to elements in
+  /// [_trackedElements]:
+  ///   mouseleave
+  ///   mouseout
+  ///   mouseenter
+  ///   mousemove
+  ///   mouseover
+  Future<void> _sendMouseEvents(Point<int> nextPos, {bool isLastStep}) async {
+    // Send 'mouseleave' and 'mouseout' events before 'mouseenter'.
+    final elementsThatLeft = await _dispatchMouseLeaves(nextPos);
+    await _dispatchMouseOuts(nextPos);
+
+    // Send 'mouseenter' and 'mousemove'.
+    final elementsThatEntered = await _dispatchMouseEnters(nextPos);
+    await _dispatchMouseMoves(nextPos);
+
+    // Send 'mouseover'.
+    await _dispatchMouseOvers(nextPos);
+
+    // Update the mouse locations on those that had 'mouseleave' or 'mouseleave'
+    // sent to them.
+    for (final element in elementsThatLeft) {
+      element.mouseIsInside = false;
+    }
+    for (final element in elementsThatEntered) {
+      element.mouseIsInside = true;
+    }
+
+    // If this is the last step, make sure new 'mousemove' is sent to the final
+    // elements with the mouse over it.
+    if (isLastStep) {
+      await _dispatchMouseMoves(nextPos);
+    }
+  }
+
+  /// Sends 'mouseenter' to elements in [_trackedElements] if needed.
+  ///
+  /// Returns a list of [TrackedElement] that had 'mouseenter' sent to them.
+  Future<List<TrackedElement>> _dispatchMouseEnters(Point nextPos) async {
+    final elementsThatEntered = <TrackedElement>[];
+    for (final element in _trackedElements) {
+      if (element.containsPoint(nextPos) && !element.mouseIsInside) {
+        await element.dispatchMouseEnter(nextPos.x, nextPos.y);
+        elementsThatEntered.add(element);
+      }
+    }
+    return elementsThatEntered;
+  }
+
+  /// Sends 'mouseleave' to elements in [_trackedElements] if needed.
+  ///
+  /// Returns a list of [TrackedElement] that had 'mouseleave' sent to them.
+  Future<List<TrackedElement>> _dispatchMouseLeaves(Point nextPos) async {
+    final elementsThatLeft = <TrackedElement>[];
+    for (final element in _trackedElements) {
+      if (!element.containsPoint(nextPos) && element.mouseIsInside) {
+        await element.dispatchMouseLeave(nextPos.x, nextPos.y);
+        elementsThatLeft.add(element);
+      }
+    }
+    return elementsThatLeft;
+  }
+
+  /// Sends 'mousemove' to elements in [_trackedElements] if needed.
+  Future<void> _dispatchMouseMoves(Point nextPos) async {
+    for (final element in _trackedElements) {
+      if (element.mouseIsInside) {
+        await element.dispatchMouseMove(nextPos.x, nextPos.y);
+      }
+    }
+  }
+
+  /// Sends 'mouseout' to elements in [_trackedElements] if needed.
+  Future<void> _dispatchMouseOuts(Point nextPos) => _dispatchBubblingEvents(
+      (TrackedElement element) => element._isLeaving(nextPos),
+      (TrackedElement element) async =>
+          await element.dispatchMouseOut(nextPos.x, nextPos.y));
+
+  /// Sends 'mouseover' to elements in [_trackedElements] if needed.
+  Future<void> _dispatchMouseOvers(Point nextPos) => _dispatchBubblingEvents(
+      (TrackedElement element) => element._isEntering(nextPos),
+      (TrackedElement element) async =>
+          await element.dispatchMouseOver(nextPos.x, nextPos.y));
+
+  /// Traverses each tree in the forest [_trackedElements] and calls
+  /// [dispatcher] on the lowest element in the tree satisfying [test], exactly
+  /// once.
+  Future<void> _dispatchBubblingEvents(bool Function(TrackedElement) test,
+      Future<void> Function(TrackedElement) dispatcher) async {
+    final _checked = new Set<TrackedElement>();
+    Future<void> _dispatch(TrackedElement target) async {
+      if (_checked.contains(target)) return;
+      _checked.add(target);
+
+      if (test(target)) {
+        for (final child in target.element.children) {
+          // It is possible that [child] was created after target was tracked.
+          final trackedChild = _track(child);
+          if (test(trackedChild)) {
+            await _dispatch(trackedChild);
+            return;
+          }
+        }
+        await dispatcher(target);
+      }
+    }
+
+    // We only need to iterate over the roots of the forest
+    // [_trackedElements], and while elements may be added to by
+    // [_dispatch], none of the new elements can be roots.
+    final potentialRoots = new List.from(_trackedElements);
+    for (final element in potentialRoots) {
+      await _dispatch(element);
+    }
+  }
+
+  Future _sleep(Duration duration) => new Future.delayed(duration);
+
+  /// Given [element], either returns an already existing [TrackedElement] for
+  /// it or creates a new [TrackedElement].
+  TrackedElement _track(Element element, {bool includeChildren = false}) {
+    final existing = _elementToTrackedElement[element];
+    if (existing != null) return existing;
+    final newTrackedElement = new TrackedElement(element);
+    _trackedElements.add(newTrackedElement);
+    _elementToTrackedElement[element] = newTrackedElement;
+    if (includeChildren) {
+      for (final child in element.children) {
+        _track(child);
+      }
+    }
+    return newTrackedElement;
+  }
 }
 
 /// execute [fn] as a separate microtask and return a [Future] that completes
 /// normally when that [Future] completes (normally or with an error).
 Future _microtask(fn()) => new Future.microtask(fn).whenComplete(() {});
+
+/// Wrapper class on [Element] to handle basic mouse tracking and sending
+/// events.
+class TrackedElement {
+  final Element element;
+  Rectangle bounds;
+  bool mouseIsInside = false;
+
+  TrackedElement(this.element);
+
+  /// Returns true if point is inside element.
+  bool containsPoint(Point p) {
+    bounds ??= element.getBoundingClientRect();
+    return bounds.containsPoint(p);
+  }
+
+  bool _isEntering(Point p) => containsPoint(p) && !mouseIsInside;
+
+  bool _isLeaving(Point p) => !containsPoint(p) && mouseIsInside;
+
+  /// Sends mouse enter event to element.
+  Future dispatchMouseEnter(int x, int y) =>
+      _microtask(() => element.dispatchEvent(new MouseEvent('mouseenter',
+          screenX: _screenX(x),
+          screenY: _screenY(y),
+          clientX: x,
+          clientY: y,
+          canBubble: false)));
+
+  /// Sends mouse over event to element or the appropriate child.
+  Future dispatchMouseOver(int x, int y) =>
+      _microtask(() => element.dispatchEvent(new MouseEvent('mouseover',
+          screenX: _screenX(x),
+          screenY: _screenY(y),
+          clientX: x,
+          clientY: y,
+          canBubble: true)));
+
+  /// Sends mouse leave event to element.
+  Future dispatchMouseLeave(int x, int y) =>
+      _microtask(() => element.dispatchEvent(new MouseEvent('mouseleave',
+          screenX: _screenX(x),
+          screenY: _screenY(y),
+          clientX: x,
+          clientY: y,
+          canBubble: false)));
+
+  /// Sends mouse out event to element or the appropriate child.
+  Future dispatchMouseOut(int x, int y) =>
+      _microtask(() => element.dispatchEvent(new MouseEvent('mouseout',
+          screenX: _screenX(x),
+          screenY: _screenY(y),
+          clientX: x,
+          clientY: y,
+          canBubble: true)));
+
+  /// Sends mouse leave event to element.
+  Future dispatchMouseMove(int x, int y) =>
+      _microtask(() => element.dispatchEvent(new MouseEvent('mousemove',
+          screenX: _screenX(x),
+          screenY: _screenY(y),
+          clientX: x,
+          clientY: y,
+          canBubble: true)));
+}
+
+/// Methods to calculate offsets.
+int _pageX(int clientX) => window.pageXOffset + clientX;
+int _pageY(int clientY) => window.pageYOffset + clientY;
+int get _borderWidth => (window.outerWidth - window.innerWidth) ~/ 2;
+int _screenX(int clientX) => window.screenLeft + _borderWidth + clientX;
+int _screenY(int clientY) =>
+    window.screenTop +
+    window.outerHeight -
+    window.innerHeight -
+    _borderWidth +
+    clientY;

--- a/lib/src/html/html_mouse.dart
+++ b/lib/src/html/html_mouse.dart
@@ -30,7 +30,7 @@ HtmlMouse globalMouse(SyncFn syncFn) {
   // indicates the scope of the [HtmlMouse] is outdated.
   if (_cachedSyncFn == null || _cachedSyncFn != syncFn) {
     _cachedSyncFn = syncFn;
-    _globalMouse = new HtmlMouse(_cachedSyncFn);
+    _globalMouse = HtmlMouse(_cachedSyncFn);
   }
   return _globalMouse;
 }
@@ -38,7 +38,7 @@ HtmlMouse globalMouse(SyncFn syncFn) {
 /// Support for mouse in in-browser context by dispatching [MouseEvent]s.
 class HtmlMouse implements PageLoaderMouse {
   // Last known coordination and the [TrackedElement] at that point.
-  var _cachedPoint = new Point<int>(0, 0);
+  var _cachedPoint = Point<int>(0, 0);
   TrackedElement _cachedElement;
   SyncFn syncFn;
 
@@ -91,8 +91,8 @@ class HtmlMouse implements PageLoaderMouse {
     xOffset ??= center.x;
     yOffset ??= center.y;
 
-    final endPoint = new Point<int>(
-        (rect.left + xOffset).ceil(), (rect.top + yOffset).ceil());
+    final endPoint =
+        Point<int>((rect.left + xOffset).ceil(), (rect.top + yOffset).ceil());
 
     // Calculate steps needed for mouse move event.
     final distance = startPoint.distanceTo(endPoint).toInt();
@@ -140,7 +140,7 @@ class HtmlMouse implements PageLoaderMouse {
   Point<int> _centerOfRect(Rectangle rect) {
     final x = (rect.width * 0.5).ceil();
     final y = (rect.height * 0.5).ceil();
-    return new Point(x, y);
+    return Point(x, y);
   }
 
   /// Calculate the next point of the current step based on [stepRatio].
@@ -151,7 +151,7 @@ class HtmlMouse implements PageLoaderMouse {
         (startPoint.x + (stepRatio * (endPoint.x - startPoint.x))).toInt();
     final y =
         (startPoint.y + (stepRatio * (endPoint.y - startPoint.y))).toInt();
-    return new Point<int>(x, y);
+    return Point<int>(x, y);
   }
 
   // Gets the current, top-most [Element] under mouse. If no element can be
@@ -163,7 +163,7 @@ class HtmlMouse implements PageLoaderMouse {
 
   Future _dispatchEvent(String type, HtmlPageLoaderElement eventTarget,
       [MouseButton button = MouseButton.primary]) async {
-    final event = new MouseEvent(type,
+    final event = MouseEvent(type,
         button: button.value,
         clientX: _cachedPoint.x,
         clientY: _cachedPoint.y,
@@ -266,7 +266,7 @@ class HtmlMouse implements PageLoaderMouse {
   /// once.
   Future<void> _dispatchBubblingEvents(bool Function(TrackedElement) test,
       Future<void> Function(TrackedElement) dispatcher) async {
-    final _checked = new Set<TrackedElement>();
+    final _checked = Set<TrackedElement>();
     Future<void> _dispatch(TrackedElement target) async {
       if (_checked.contains(target)) return;
       _checked.add(target);
@@ -287,20 +287,20 @@ class HtmlMouse implements PageLoaderMouse {
     // We only need to iterate over the roots of the forest
     // [_trackedElements], and while elements may be added to by
     // [_dispatch], none of the new elements can be roots.
-    final potentialRoots = new List.from(_trackedElements);
+    final potentialRoots = List.from(_trackedElements);
     for (final element in potentialRoots) {
       await _dispatch(element);
     }
   }
 
-  Future _sleep(Duration duration) => new Future.delayed(duration);
+  Future _sleep(Duration duration) => Future.delayed(duration);
 
   /// Given [element], either returns an already existing [TrackedElement] for
   /// it or creates a new [TrackedElement].
   TrackedElement _track(Element element, {bool includeChildren = false}) {
     final existing = _elementToTrackedElement[element];
     if (existing != null) return existing;
-    final newTrackedElement = new TrackedElement(element);
+    final newTrackedElement = TrackedElement(element);
     _trackedElements.add(newTrackedElement);
     _elementToTrackedElement[element] = newTrackedElement;
     if (includeChildren) {
@@ -314,7 +314,7 @@ class HtmlMouse implements PageLoaderMouse {
 
 /// execute [fn] as a separate microtask and return a [Future] that completes
 /// normally when that [Future] completes (normally or with an error).
-Future _microtask(fn()) => new Future.microtask(fn).whenComplete(() {});
+Future _microtask(fn()) => Future.microtask(fn).whenComplete(() {});
 
 /// Wrapper class on [Element] to handle basic mouse tracking and sending
 /// events.
@@ -337,7 +337,7 @@ class TrackedElement {
 
   /// Sends mouse enter event to element.
   Future dispatchMouseEnter(int x, int y) =>
-      _microtask(() => element.dispatchEvent(new MouseEvent('mouseenter',
+      _microtask(() => element.dispatchEvent(MouseEvent('mouseenter',
           screenX: _screenX(x),
           screenY: _screenY(y),
           clientX: x,
@@ -346,7 +346,7 @@ class TrackedElement {
 
   /// Sends mouse over event to element or the appropriate child.
   Future dispatchMouseOver(int x, int y) =>
-      _microtask(() => element.dispatchEvent(new MouseEvent('mouseover',
+      _microtask(() => element.dispatchEvent(MouseEvent('mouseover',
           screenX: _screenX(x),
           screenY: _screenY(y),
           clientX: x,
@@ -355,7 +355,7 @@ class TrackedElement {
 
   /// Sends mouse leave event to element.
   Future dispatchMouseLeave(int x, int y) =>
-      _microtask(() => element.dispatchEvent(new MouseEvent('mouseleave',
+      _microtask(() => element.dispatchEvent(MouseEvent('mouseleave',
           screenX: _screenX(x),
           screenY: _screenY(y),
           clientX: x,
@@ -364,7 +364,7 @@ class TrackedElement {
 
   /// Sends mouse out event to element or the appropriate child.
   Future dispatchMouseOut(int x, int y) =>
-      _microtask(() => element.dispatchEvent(new MouseEvent('mouseout',
+      _microtask(() => element.dispatchEvent(MouseEvent('mouseout',
           screenX: _screenX(x),
           screenY: _screenY(y),
           clientX: x,
@@ -373,7 +373,7 @@ class TrackedElement {
 
   /// Sends mouse leave event to element.
   Future dispatchMouseMove(int x, int y) =>
-      _microtask(() => element.dispatchEvent(new MouseEvent('mousemove',
+      _microtask(() => element.dispatchEvent(MouseEvent('mousemove',
           screenX: _screenX(x),
           screenY: _screenY(y),
           clientX: x,

--- a/lib/src/html/html_page_loader_element.dart
+++ b/lib/src/html/html_page_loader_element.dart
@@ -138,7 +138,7 @@ class HtmlPageLoaderElement implements PageLoaderElement {
 
     Iterable<Element> elements;
     if (_finder == null) {
-      elements = [base];
+      elements = [_cachedElement ?? base];
     } else if (_finder is ContextFinder) {
       elements = (_finder as ContextFinder)
           .findElements(this._parentElement)
@@ -244,6 +244,9 @@ class HtmlPageLoaderElement implements PageLoaderElement {
       });
 
   @override
+  PageLoaderElement byTag(String tagName) => getElementsByCss(tagName).single;
+
+  @override
   Future<Null> clear({bool focusBefore: true, bool blurAfter: true}) async =>
       syncFn(() async => _retryWhenStale(() async {
             final element = _single;
@@ -280,6 +283,12 @@ class HtmlPageLoaderElement implements PageLoaderElement {
 
         return _microtask(element.click);
       }));
+
+  @override
+  Future<void> clickOutside() async {
+    if (!exists || !displayed || utils.root == this) return;
+    await utils.root.click();
+  }
 
   Future<Null> _clickOptionElement() async => _retryWhenStale(() async {
         final option = _single as OptionElement;

--- a/lib/src/html/html_page_loader_element.dart
+++ b/lib/src/html/html_page_loader_element.dart
@@ -56,7 +56,7 @@ class HtmlPageLoaderElement implements PageLoaderElement {
   @override
   HtmlPageLoaderElement createElement(
       Finder finder, List<Filter> filters, List<Checker> checkers) {
-    return new HtmlPageLoaderElement(externalSyncFn: this.syncFn)
+    return HtmlPageLoaderElement(externalSyncFn: this.syncFn)
       .._finder = finder
       .._filters = filters
       .._checkers = checkers
@@ -67,13 +67,12 @@ class HtmlPageLoaderElement implements PageLoaderElement {
   @override
   HtmlPageElementIterable createIterable(
           Finder finder, List<Filter> filters, List<Checker> checkers) =>
-      new HtmlPageElementIterable(
-          new HtmlPageLoaderElement(externalSyncFn: this.syncFn)
-            .._finder = finder
-            .._filters = filters
-            .._checkers = checkers
-            .._listeners = this._listeners
-            .._parentElement = this);
+      HtmlPageElementIterable(HtmlPageLoaderElement(externalSyncFn: this.syncFn)
+        .._finder = finder
+        .._filters = filters
+        .._checkers = checkers
+        .._listeners = this._listeners
+        .._parentElement = this);
 
   /// Create a new list using the current element as the parent context.
   @override
@@ -81,7 +80,7 @@ class HtmlPageLoaderElement implements PageLoaderElement {
       Finder finder, List<Filter> filter, List<Checker> checkers) {
     final rootElement = createElement(finder, filter, checkers);
     final createdList = (rootElement.elements)
-        .map((elem) => new HtmlPageLoaderElement.createFromElement(elem,
+        .map((elem) => HtmlPageLoaderElement.createFromElement(elem,
             externalSyncFn: syncFn))
         .toList();
     createdList.forEach((elem) => elem.addListeners(_listeners));
@@ -103,7 +102,7 @@ class HtmlPageLoaderElement implements PageLoaderElement {
   List<PageLoaderListener> get listeners => _listeners;
 
   @override
-  PageUtils get utils => new HtmlPageUtils(externalSyncFn: syncFn);
+  PageUtils get utils => HtmlPageUtils(externalSyncFn: syncFn);
 
   @deprecated
   @override
@@ -120,9 +119,9 @@ class HtmlPageLoaderElement implements PageLoaderElement {
 
     final elems = elements;
     if (elems.isEmpty) {
-      throw new FoundZeroElementsInSingleException(this);
+      throw FoundZeroElementsInSingleException(this);
     } else if (elems.length > 1) {
-      throw new FoundMultipleElementsInSingleException(this);
+      throw FoundMultipleElementsInSingleException(this);
     }
     _cachedElement = elems[0];
     return _cachedElement;
@@ -151,7 +150,7 @@ class HtmlPageLoaderElement implements PageLoaderElement {
 
     // Filter/Checker API is based on PageLoaderElements; casting for this.
     final tempElements = elements
-        .map((e) => new HtmlPageLoaderElement._castFromElement(this.syncFn, e))
+        .map((e) => HtmlPageLoaderElement._castFromElement(this.syncFn, e))
         .toList();
     final filteredElements =
         core.applyFiltersAndChecks(tempElements, _filters, _checkers);
@@ -190,19 +189,19 @@ class HtmlPageLoaderElement implements PageLoaderElement {
   String get name => _retryWhenStale(() => _single.tagName.toLowerCase());
 
   @override
-  PageLoaderAttributes get attributes => new _ElementAttributes(this);
+  PageLoaderAttributes get attributes => _ElementAttributes(this);
 
   @override
   PageLoaderAttributes get seleniumAttributes => attributes;
 
   @override
-  PageLoaderAttributes get properties => new _ElementProperties(this);
+  PageLoaderAttributes get properties => _ElementProperties(this);
 
   @override
-  PageLoaderAttributes get computedStyle => new _ElementComputedStyle(this);
+  PageLoaderAttributes get computedStyle => _ElementComputedStyle(this);
 
   @override
-  PageLoaderAttributes get style => new _ElementStyle(this);
+  PageLoaderAttributes get style => _ElementStyle(this);
 
   @override
   bool get displayed =>
@@ -221,7 +220,7 @@ class HtmlPageLoaderElement implements PageLoaderElement {
     if (count == 1)
       return true;
     else if (count == 0) return false;
-    throw new PageLoaderException.withContext(
+    throw PageLoaderException.withContext(
         'Found $count elements on call to exists', this);
   }
 
@@ -238,7 +237,7 @@ class HtmlPageLoaderElement implements PageLoaderElement {
         final element = _single;
         return element
             .querySelectorAll(selector)
-            .map((elem) => new HtmlPageLoaderElement.createFromElement(elem,
+            .map((elem) => HtmlPageLoaderElement.createFromElement(elem,
                 externalSyncFn: syncFn))
             .toList();
       });
@@ -253,13 +252,12 @@ class HtmlPageLoaderElement implements PageLoaderElement {
             if (_hasValueProperty(element)) {
               if (focusBefore) await focus();
               _setValue(element, '');
+              await _microtask(() => element.dispatchEvent(TextEvent('input')));
               await _microtask(
-                  () => element.dispatchEvent(new TextEvent('input')));
-              await _microtask(
-                  () => element.dispatchEvent(new TextEvent('change')));
+                  () => element.dispatchEvent(TextEvent('change')));
               if (blurAfter) await blur();
             } else {
-              throw new PageLoaderException(
+              throw PageLoaderException(
                   '${element.runtimeType} does not support clear.');
             }
           }));
@@ -271,14 +269,14 @@ class HtmlPageLoaderElement implements PageLoaderElement {
           return _clickOptionElement();
         }
 
-        await _microtask(() => element
-            .dispatchEvent(new Event.eventType('MouseEvent', 'mousedown')));
-        await _microtask(() => element
-            .dispatchEvent(new Event.eventType('MouseEvent', 'mouseup')));
+        await _microtask(() =>
+            element.dispatchEvent(Event.eventType('MouseEvent', 'mousedown')));
+        await _microtask(() =>
+            element.dispatchEvent(Event.eventType('MouseEvent', 'mouseup')));
 
         if (element is SvgElement) {
-          return _microtask(() => element
-              .dispatchEvent(new Event.eventType('MouseEvent', 'click')));
+          return _microtask(() =>
+              element.dispatchEvent(Event.eventType('MouseEvent', 'click')));
         }
 
         return _microtask(element.click);
@@ -293,7 +291,7 @@ class HtmlPageLoaderElement implements PageLoaderElement {
   Future<Null> _clickOptionElement() async => _retryWhenStale(() async {
         final option = _single as OptionElement;
         option.selected = true;
-        return _microtask(() => option.dispatchEvent(new Event('change')));
+        return _microtask(() => option.dispatchEvent(Event('change')));
       });
 
   @override
@@ -305,10 +303,8 @@ class HtmlPageLoaderElement implements PageLoaderElement {
             await _fireKeyPressEvents(node, keys.length);
             if (_hasValueProperty(node)) {
               _setValue(node, _getValue(node) + keys);
-              await _microtask(
-                  () => node.dispatchEvent(new TextEvent('input')));
-              await _microtask(
-                  () => node.dispatchEvent(new TextEvent('change')));
+              await _microtask(() => node.dispatchEvent(TextEvent('input')));
+              await _microtask(() => node.dispatchEvent(TextEvent('change')));
             }
             if (blurAfter) await blur();
           }));
@@ -319,8 +315,7 @@ class HtmlPageLoaderElement implements PageLoaderElement {
   // key presses instead.
   Future<Null> _fireKeyPressEvents(Element element, int numKeys) async {
     for (int i = 0; i < numKeys; ++i) {
-      await _microtask(
-          () => element.dispatchEvent(new KeyboardEvent('keypress')));
+      await _microtask(() => element.dispatchEvent(KeyboardEvent('keypress')));
     }
   }
 
@@ -371,7 +366,7 @@ class _ElementProperties extends PageLoaderAttributes {
 
   @override
   String operator [](String name) => core.staleElementWrapper(() {
-        final object = new js.JsObject.fromBrowserObject(_node._single);
+        final object = js.JsObject.fromBrowserObject(_node._single);
         if (object.hasProperty(name)) {
           return object[name].toString();
         }
@@ -399,7 +394,7 @@ bool _hasValueProperty(Element element) =>
 String _getValue(Element element) {
   if (element is InputElementBase) return element.value;
   if (element is TextAreaElement) return element.value;
-  throw new PageLoaderException(
+  throw PageLoaderException(
       'Cannot find value for type: ${element.runtimeType}');
 }
 
@@ -412,14 +407,14 @@ void _setValue(Element element, String value) {
     element.value = value;
     return;
   }
-  throw new PageLoaderException(
+  throw PageLoaderException(
       'Cannot find value for type: ${element.runtimeType}');
 }
 
 // execute [fn] as a separate microtask and return a [Future] that completes
 // normally when that [Future] completes (normally or with an error).
 Future<Null> _microtask(fn()) {
-  return new Future<Null>.microtask(() {
+  return Future<Null>.microtask(() {
     fn();
   }).whenComplete(() {});
 }
@@ -445,12 +440,12 @@ String _elementText(List<Node> elements) {
   return _elementText(elem.nodes);
 }
 
-final _nonBreaking = new RegExp(r'^[\S\xa0]$');
+final _nonBreaking = RegExp(r'^[\S\xa0]$');
 
 String _normalize(String string) {
   var skipWS = true;
   var addWS = false;
-  final buffer = new StringBuffer();
+  final buffer = StringBuffer();
   for (int i = 0; i < string.length; i++) {
     final char = string[i];
     if (char.contains(_nonBreaking)) {

--- a/lib/src/html/html_page_utils.dart
+++ b/lib/src/html/html_page_utils.dart
@@ -32,7 +32,7 @@ class HtmlPageUtils extends PageUtils {
   /// to persist.
   @override
   HtmlPageLoaderElement get root {
-    _cachedRoot ??= new HtmlPageLoaderElement.createFromElement(document.body,
+    _cachedRoot ??= HtmlPageLoaderElement.createFromElement(document.body,
         externalSyncFn: this.syncFn);
     return _cachedRoot;
   }
@@ -42,7 +42,7 @@ class HtmlPageUtils extends PageUtils {
   /// This is element you should pass in your tests to create new page objects.
   @override
   PageLoaderElement byTag(String tag) =>
-      new HtmlPageLoaderElement.createFromElement(document.body,
+      HtmlPageLoaderElement.createFromElement(document.body,
               externalSyncFn: this.syncFn)
           .getElementsByCss(tag)
           .single;

--- a/lib/src/html/html_page_utils.dart
+++ b/lib/src/html/html_page_utils.dart
@@ -21,12 +21,10 @@ import 'html_page_loader_element.dart';
 /// Support for [PageUtils] in HTML context.
 class HtmlPageUtils extends PageUtils {
   final SyncFn syncFn;
-  final HtmlMouse _mouse;
   HtmlPageLoaderElement _cachedRoot;
 
   HtmlPageUtils({SyncFn externalSyncFn: noOpExecuteSyncedFn})
-      : syncFn = externalSyncFn,
-        _mouse = new HtmlMouse(externalSyncFn);
+      : syncFn = externalSyncFn;
 
   /// Gets the body for the current page.
   ///
@@ -51,5 +49,5 @@ class HtmlPageUtils extends PageUtils {
 
   /// Gets the mouse.
   @override
-  PageLoaderMouse get mouse => _mouse;
+  PageLoaderMouse get mouse => globalMouse(this.syncFn);
 }

--- a/lib/src/matchers/matchers.dart
+++ b/lib/src/matchers/matchers.dart
@@ -15,18 +15,18 @@ import 'package:matcher/matcher.dart';
 import 'package:pageloader/utils.dart' as utils;
 
 /// A matcher that checks if a PageLoaderElement/PageObject exists.
-const Matcher exists = const _Exists();
+const Matcher exists = _Exists();
 
 /// A matcher that checks if a PageLoaderElement/PageObject does not exist.
 Matcher notExists = isNot(exists);
 
 /// A matcher that checks if a PageLoaderElement/PageObject
 /// contains given class.
-Matcher hasClass(String className) => new _HasClass(className);
+Matcher hasClass(String className) => _HasClass(className);
 
 /// A matcher that checks if a PageLoaderElement/PageObject is displayed
 /// based on "display" style.
-const Matcher isDisplayed = const _IsDisplayed();
+const Matcher isDisplayed = _IsDisplayed();
 
 /// A matcher that checks if a PageLoaderElement/PageObject is not displayed
 /// based on "display" style.
@@ -37,19 +37,19 @@ Matcher isNotDisplayed = isNot(isDisplayed);
 /// Checks that the item's `visibility` is `hidden` or `collapse`.
 /// Does not check whether the item has been hidden by other means, e.g., being
 /// obscured by other elements.
-const Matcher isHidden = const _IsHidden();
+const Matcher isHidden = _IsHidden();
 
 /// A matcher that checks if a PageLoaderElement/PageObject is not hidden.
 Matcher isNotHidden = isNot(isHidden);
 
 /// A matcher that checks if PageLoaderElement/PageObject is focused.
-const Matcher isFocused = const _IsFocused();
+const Matcher isFocused = _IsFocused();
 
 /// A matcher that checks if PageLoaderElement/PageObject is not focused.
 Matcher isNotFocused = isNot(isFocused);
 
 /// A matcher that matches the given matcher against an element's inner text.
-Matcher hasInnerText(matcher) => new _HasInnerText(matcher);
+Matcher hasInnerText(matcher) => _HasInnerText(matcher);
 
 const _item = 'PageLoaderElement/PageObject';
 

--- a/lib/src/webdriver/webdriver_iterators.dart
+++ b/lib/src/webdriver/webdriver_iterators.dart
@@ -34,8 +34,7 @@ class WebDriverPageElementIterator
     if (_current == -1) {
       return null;
     }
-    return new WebDriverPageLoaderElement.createFromElement(
-        _elements[_current]);
+    return WebDriverPageLoaderElement.createFromElement(_elements[_current]);
   }
 }
 
@@ -51,12 +50,11 @@ class WebDriverPageElementIterable extends PageElementIterable {
 
   @override
   Future<PageLoaderElement> get first async =>
-      new WebDriverPageLoaderElement.createFromElement(
-          _drivingElement.elements[0]);
+      WebDriverPageLoaderElement.createFromElement(_drivingElement.elements[0]);
 
   @override
   Future<Iterator<PageLoaderElement>> get iterator async {
-    return new WebDriverPageElementIterator(_drivingElement.elements);
+    return WebDriverPageElementIterator(_drivingElement.elements);
   }
 
   @override

--- a/lib/src/webdriver/webdriver_mouse.dart
+++ b/lib/src/webdriver/webdriver_mouse.dart
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import 'dart:async';
+import 'dart:core';
 
 import 'package:pageloader/pageloader.dart';
 import 'package:webdriver/sync_core.dart' as wd;
@@ -38,16 +39,13 @@ class WebDriverMouse implements PageLoaderMouse {
 
   @override
   Future moveTo(PageLoaderElement element, int xOffset, int yOffset,
-      {PageLoaderElement eventTarget}) async {
-    if (eventTarget is WebDriverPageLoaderElement) {
-      return _fireEvent(eventTarget, 'mousemove');
-    } else {
-      return _driver.mouse.moveTo(
+          {List<PageLoaderElement> dispatchTo,
+          int stepPixels,
+          Duration duration}) async =>
+      _driver.mouse.moveTo(
           element: (element as WebDriverPageLoaderElement).contextSync,
           xOffset: xOffset,
           yOffset: yOffset);
-    }
-  }
 
   @override
   Future up(MouseButton button, {PageLoaderElement eventTarget}) async {

--- a/lib/src/webdriver/webdriver_page_loader_element.dart
+++ b/lib/src/webdriver/webdriver_page_loader_element.dart
@@ -43,7 +43,7 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
   /// Constructs an element without context. Corresponds to the global context,
   /// i.e. the root HTML node.
   WebDriverPageLoaderElement(this._driver)
-      : _utils = new WebDriverPageUtils(_driver),
+      : _utils = WebDriverPageUtils(_driver),
         _cachedElement = null,
         _finder = null,
         _filters = <Filter>[],
@@ -56,10 +56,10 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
   /// Constructs an element from a [WebElement].
   WebDriverPageLoaderElement.createFromElement(sync_wd.WebElement element) {
     this._driver = element.driver;
-    this._utils = new WebDriverPageUtils(_driver);
+    this._utils = WebDriverPageUtils(_driver);
     this._parentElement = null;
     this._cachedElement = element;
-    _finder = new WebElementFinder(element);
+    _finder = WebElementFinder(element);
     _filters = [];
     _checkers = [];
     _listeners = [];
@@ -70,7 +70,7 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
   @override
   WebDriverPageLoaderElement createElement(
       Finder finder, List<Filter> filters, List<Checker> checkers) {
-    return new WebDriverPageLoaderElement(this._driver)
+    return WebDriverPageLoaderElement(this._driver)
       .._finder = finder
       .._filters = filters
       .._checkers = checkers
@@ -83,13 +83,12 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
   @override
   WebDriverPageElementIterable createIterable(
           Finder finder, List<Filter> filters, List<Checker> checkers) =>
-      new WebDriverPageElementIterable(
-          new WebDriverPageLoaderElement(this._driver)
-            .._finder = finder
-            .._filters = filters
-            .._checkers = checkers
-            .._listeners = this._listeners
-            .._parentElement = this);
+      WebDriverPageElementIterable(WebDriverPageLoaderElement(this._driver)
+        .._finder = finder
+        .._filters = filters
+        .._checkers = checkers
+        .._listeners = this._listeners
+        .._parentElement = this);
 
   /// Create a new list using the current element as the parent context.
   @override
@@ -97,7 +96,7 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
       Finder finder, List<Filter> filter, List<Checker> checkers) {
     final rootElement = createElement(finder, filter, checkers);
     final createdList = (rootElement.elements)
-        .map((elem) => new WebDriverPageLoaderElement.createFromElement(elem))
+        .map((elem) => WebDriverPageLoaderElement.createFromElement(elem))
         .toList();
     createdList.forEach((elem) => elem.addListeners(_listeners));
     return createdList;
@@ -139,9 +138,9 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
 
     final elems = elements;
     if (elems.isEmpty) {
-      throw new FoundZeroElementsInSingleException(this);
+      throw FoundZeroElementsInSingleException(this);
     } else if (elems.length > 1) {
-      throw new FoundMultipleElementsInSingleException(this);
+      throw FoundMultipleElementsInSingleException(this);
     }
     _cachedElement = elems[0];
     return _cachedElement;
@@ -151,13 +150,12 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
   List<sync_wd.WebElement> get elements {
     sync_wd.WebElement base;
     if (_parentElement == null) {
-      final root =
-          _driver.findElements(new sync_wd.By.tagName('html')).toList();
+      final root = _driver.findElements(sync_wd.By.tagName('html')).toList();
       if (root.isEmpty) {
-        throw new PageLoaderException('Could not find HTML tag at root');
+        throw PageLoaderException('Could not find HTML tag at root');
       }
       if (root.length > 1) {
-        throw new PageLoaderException('Found multiple HTML tags');
+        throw PageLoaderException('Found multiple HTML tags');
       }
       base = root[0];
     } else {
@@ -176,7 +174,7 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
     } else if (_finder is CssFinder) {
       elements = base
           .findElements(
-              new sync_wd.By.cssSelector((_finder as CssFinder).cssSelector))
+              sync_wd.By.cssSelector((_finder as CssFinder).cssSelector))
           .toList();
     } else {
       throw 'Unknown Finder type, ${_finder.runtimeType}';
@@ -184,7 +182,7 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
 
     // Filter/Checker API is based on PageLoaderElements; casting for this.
     final tempElements = elements
-        .map((e) => new WebDriverPageLoaderElement._castFromElement(e))
+        .map((e) => WebDriverPageLoaderElement._castFromElement(e))
         .toList();
     final filteredElements =
         core.applyFiltersAndChecks(tempElements, _filters, _checkers);
@@ -226,21 +224,21 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
 
   @override
   PageLoaderAttributes get attributes =>
-      _retryWhenStale(() => new _ElementAttributes(this));
+      _retryWhenStale(() => _ElementAttributes(this));
 
   @override
   PageLoaderAttributes get seleniumAttributes => attributes;
 
   @override
   PageLoaderAttributes get properties =>
-      _retryWhenStale(() => new _ElementProperties(this));
+      _retryWhenStale(() => _ElementProperties(this));
 
   @override
   PageLoaderAttributes get computedStyle =>
-      _retryWhenStale(() => new _ElementComputedStyle(this));
+      _retryWhenStale(() => _ElementComputedStyle(this));
 
   @override
-  PageLoaderAttributes get style => new _ElementStyle(this);
+  PageLoaderAttributes get style => _ElementStyle(this);
 
   @override
   bool get displayed => _retryWhenStale(() => _single.displayed);
@@ -263,7 +261,7 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
     if (count == 1)
       return true;
     else if (count == 0) return false;
-    throw new PageLoaderException.withContext(
+    throw PageLoaderException.withContext(
         'Found $count elements on call to exists', this);
   }
 
@@ -275,7 +273,7 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
           width: arguments[0].offsetWidth,
           height: arguments[0].offsetHeight
         }''', [_single]));
-    return new Rectangle<num>(
+    return Rectangle<num>(
         rect['left'], rect['top'], rect['width'], rect['height']);
   }
 
@@ -283,15 +281,15 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
   Rectangle getBoundingClientRect() {
     final rect = _retryWhenStale<Map>(() => _driver
         .execute('return arguments[0].getBoundingClientRect();', [_single]));
-    return new Rectangle<num>(
+    return Rectangle<num>(
         rect['left'], rect['top'], rect['width'], rect['height']);
   }
 
   @override
   List<WebDriverPageLoaderElement> getElementsByCss(String selector) =>
       _retryWhenStale(() => _single
-          .findElements(new sync_wd.By.cssSelector(selector))
-          .map((elem) => new WebDriverPageLoaderElement.createFromElement(elem))
+          .findElements(sync_wd.By.cssSelector(selector))
+          .map((elem) => WebDriverPageLoaderElement.createFromElement(elem))
           .map((elem) => elem..addListeners(this.listeners))
           .toList());
 
@@ -317,7 +315,7 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
     if (!exists || !displayed) return;
 
     final rect = getBoundingClientRect();
-    await _retryWhenStale<void>(() {
+    await _retryWhenStale<void>(() { // ignore: await_only_futures
       final bodyElement = _utils.byTag('body');
       final bodyRect = bodyElement.getBoundingClientRect();
       if (!rect.intersects(bodyRect)) {
@@ -341,7 +339,7 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
             yOffset: point.y.toInt() - bodyRect.top);
         _utils.driver.mouse.click();
       } else {
-        throw new PageLoaderException(
+        throw PageLoaderException(
             'Could not click outside of the current element [$this].'
             ' It is because it covers the whole <body>.');
       }
@@ -432,5 +430,5 @@ class _ElementStyle extends PageLoaderAttributes {
 }
 
 /// Convert hyphenated-properties to camelCase.
-String _cssPropName(String name) => name.splitMapJoin(new RegExp(r'-(\w)'),
+String _cssPropName(String name) => name.splitMapJoin(RegExp(r'-(\w)'),
     onMatch: (m) => m.group(1).toUpperCase(), onNonMatch: (m) => m);

--- a/lib/src/webdriver/webdriver_page_loader_element.dart
+++ b/lib/src/webdriver/webdriver_page_loader_element.dart
@@ -225,16 +225,19 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
   String get name => _retryWhenStale(() => _single.name);
 
   @override
-  PageLoaderAttributes get attributes => new _ElementAttributes(this);
+  PageLoaderAttributes get attributes =>
+      _retryWhenStale(() => new _ElementAttributes(this));
 
   @override
   PageLoaderAttributes get seleniumAttributes => attributes;
 
   @override
-  PageLoaderAttributes get properties => new _ElementProperties(this);
+  PageLoaderAttributes get properties =>
+      _retryWhenStale(() => new _ElementProperties(this));
 
   @override
-  PageLoaderAttributes get computedStyle => new _ElementComputedStyle(this);
+  PageLoaderAttributes get computedStyle =>
+      _retryWhenStale(() => new _ElementComputedStyle(this));
 
   @override
   PageLoaderAttributes get style => new _ElementStyle(this);

--- a/lib/src/webdriver/webdriver_page_loader_element.dart
+++ b/lib/src/webdriver/webdriver_page_loader_element.dart
@@ -317,7 +317,7 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
     if (!exists || !displayed) return;
 
     final rect = getBoundingClientRect();
-    _retryWhenStale<void>(() {
+    await _retryWhenStale<void>(() {
       final bodyElement = _utils.byTag('body');
       final bodyRect = bodyElement.getBoundingClientRect();
       if (!rect.intersects(bodyRect)) {

--- a/lib/src/webdriver/webdriver_page_utils.dart
+++ b/lib/src/webdriver/webdriver_page_utils.dart
@@ -26,7 +26,7 @@ class WebDriverPageUtils extends PageUtils {
 
   WebDriverPageLoaderElement _cachedRoot;
 
-  WebDriverPageUtils(this.driver) : _mouse = new WebDriverMouse(driver);
+  WebDriverPageUtils(this.driver) : _mouse = WebDriverMouse(driver);
 
   /// Gets the root element for the given page.
   ///
@@ -34,7 +34,7 @@ class WebDriverPageUtils extends PageUtils {
   /// listeners to persist.
   @override
   WebDriverPageLoaderElement get root {
-    _cachedRoot ??= new WebDriverPageLoaderElement(driver);
+    _cachedRoot ??= WebDriverPageLoaderElement(driver);
     return _cachedRoot;
   }
 

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -56,7 +56,7 @@ bool isDisplayed(item) =>
 /// "display" style.
 bool isNotDisplayed(item) => !isDisplayed(item);
 
-const _hidden = const ['hidden', 'collapse'];
+const _hidden = ['hidden', 'collapse'];
 
 /// Checks if a PageLoaderElement/PageObject is hidden based on "visibility"
 /// style.
@@ -83,15 +83,15 @@ String getInnerText(item) =>
     _rootElementOfAndRethrow(item, 'getInnerText').innerText;
 
 /// Function for PageObject constructor. Typically in form:
-///   (c) => new SomePO.create(c)
+///   (c) => SomePO.create(c)
 typedef T POFactory<T>(PageLoaderElement context);
 
 /// Generates PO of type T using [source] as context. If [finder] is provided,
 /// creates a new PO using context plus [finder].
 ///
 /// Example:
-///   final myPO = createPO<MyPO>(someElement, (c) => new MyPO.create(c),
-///       finder: const ByCss('some-tag'));
+///   final myPO = createPO<MyPO>(someElement, (c) => MyPO.create(c),
+///       finder: ByCss('some-tag'));
 T createPO<T>(PageLoaderElement source, POFactory<T> poFactory,
     {Finder finder}) {
   final element =
@@ -109,7 +109,7 @@ PageLoaderElement rootElementOf(item) {
   try {
     return item.$root;
   } on NoSuchMethodError {
-    throw new PageLoaderArgumentError.onWrongType('rootElementOf');
+    throw PageLoaderArgumentError.onWrongType('rootElementOf');
   }
 }
 
@@ -121,7 +121,7 @@ PageLoaderElement _rootElementOfAndRethrow(item, String f) {
   try {
     _root = rootElementOf(item);
   } on PageLoaderArgumentError {
-    throw new PageLoaderArgumentError.onWrongType(f);
+    throw PageLoaderArgumentError.onWrongType(f);
   }
   return _root;
 }
@@ -130,6 +130,6 @@ class PageLoaderArgumentError extends ArgumentError {
   PageLoaderArgumentError._(String message) : super(message);
 
   factory PageLoaderArgumentError.onWrongType(String f) =>
-      new PageLoaderArgumentError._("'$f' may only be called on PageObjects "
+      PageLoaderArgumentError._("'$f' may only be called on PageObjects "
           "or PageLoaderElements");
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pageloader
 
-version: 3.0.0-beta
+version: 3.0.0-dev
 
 authors:
   - Marc Fisher II (emeritus) <fisherii@google.com>

--- a/test/core_method_information_test.dart
+++ b/test/core_method_information_test.dart
@@ -50,7 +50,7 @@ void main() {
       expect(info.isFuture, false);
       expect(info.isList, false);
       expect(info.finder.isPresent, true);
-      expect(info.finder.value, 'const ByTagName("myid")');
+      expect(info.finder.value, 'ByTagName("myid")');
       expect(info.filters, isEmpty);
       expect(info.checkers, isEmpty);
     });
@@ -70,7 +70,7 @@ void main() {
       expect(info.isFuture, false);
       expect(info.isList, false);
       expect(info.finder.isPresent, true);
-      expect(info.finder.value, 'const ByTagName("myid")');
+      expect(info.finder.value, 'ByTagName("myid")');
       expect(info.filters, isEmpty);
       expect(info.checkers, hasLength(1));
     });
@@ -90,7 +90,7 @@ void main() {
       expect(info.isFuture, false);
       expect(info.isList, false);
       expect(info.finder.isPresent, true);
-      expect(info.finder.value, 'const ByTagName("myid")');
+      expect(info.finder.value, 'ByTagName("myid")');
       expect(info.filters, hasLength(1));
       expect(info.checkers, isEmpty);
     });
@@ -109,7 +109,7 @@ void main() {
       expect(info.isFuture, true);
       expect(info.isList, false);
       expect(info.finder.isPresent, true);
-      expect(info.finder.value, 'const ByTagName("myid")');
+      expect(info.finder.value, 'ByTagName("myid")');
       expect(info.filters, isEmpty);
       expect(info.checkers, isEmpty);
     });
@@ -129,7 +129,7 @@ void main() {
       expect(info.isFuture, true);
       expect(info.isList, true);
       expect(info.finder.isPresent, true);
-      expect(info.finder.value, 'const ByTagName("myid")');
+      expect(info.finder.value, 'ByTagName("myid")');
       expect(info.filters, isEmpty);
       expect(info.checkers, isEmpty);
     });
@@ -148,7 +148,7 @@ void main() {
       expect(info.isFuture, false);
       expect(info.isList, true);
       expect(info.finder.isPresent, true);
-      expect(info.finder.value, 'const ByTagName("myid")');
+      expect(info.finder.value, 'ByTagName("myid")');
       expect(info.filters, isEmpty);
       expect(info.checkers, isEmpty);
     });
@@ -239,7 +239,7 @@ class MyAnnotation implements CssFinder {
       expect(info.isFuture, false);
       expect(info.isList, false);
       expect(info.finder.isPresent, true);
-      expect(info.finder.value, 'const MyAnnotation("myid")');
+      expect(info.finder.value, 'MyAnnotation("myid")');
       expect(info.filters, isEmpty);
       expect(info.checkers, isEmpty);
     });
@@ -275,7 +275,7 @@ class MyAnnotation implements CssFinder, Checker {
       expect(info.isFuture, false);
       expect(info.isList, false);
       expect(info.finder.isPresent, true);
-      expect(info.finder.value, 'const MyAnnotation("myid")');
+      expect(info.finder.value, 'MyAnnotation("myid")');
       expect(info.filters, isEmpty);
       expect(info.checkers, hasLength(1));
     });
@@ -317,7 +317,7 @@ class MyAnnotation implements CssFinder, Filter {
       expect(info.isFuture, false);
       expect(info.isList, false);
       expect(info.finder.isPresent, true);
-      expect(info.finder.value, 'const MyAnnotation("myid", "att", "")');
+      expect(info.finder.value, 'MyAnnotation("myid", "att", "")');
       expect(info.filters, hasLength(1));
       expect(info.checkers, isEmpty);
     });
@@ -337,7 +337,7 @@ class MyAnnotation implements CssFinder, Filter {
       expect(info.isFuture, true);
       expect(info.isList, false);
       expect(info.finder.isPresent, true);
-      expect(info.finder.value, 'const MyAnnotation("myid")');
+      expect(info.finder.value, 'MyAnnotation("myid")');
       expect(info.filters, isEmpty);
       expect(info.checkers, isEmpty);
     });
@@ -358,7 +358,7 @@ class MyAnnotation implements CssFinder, Filter {
       expect(info.isFuture, true);
       expect(info.isList, true);
       expect(info.finder.isPresent, true);
-      expect(info.finder.value, 'const MyAnnotation("myid")');
+      expect(info.finder.value, 'MyAnnotation("myid")');
       expect(info.filters, isEmpty);
       expect(info.checkers, isEmpty);
     });
@@ -378,7 +378,7 @@ class MyAnnotation implements CssFinder, Filter {
       expect(info.isFuture, false);
       expect(info.isList, true);
       expect(info.finder.isPresent, true);
-      expect(info.finder.value, 'const MyAnnotation("myid")');
+      expect(info.finder.value, 'MyAnnotation("myid")');
       expect(info.filters, isEmpty);
       expect(info.checkers, isEmpty);
     });

--- a/test/correct_gen_test.dart
+++ b/test/correct_gen_test.dart
@@ -28,26 +28,26 @@ import 'examples/correct/unannotated.dart';
 import 'generation_test_setup/dummy_page_loader_element.dart';
 
 void main() {
-  final context = () => new DummyPageLoaderElement();
+  final context = () => DummyPageLoaderElement();
 
   group('non-mixin', () {
     test('class checks work', () {
-      final classChecks = new ClassChecks.create(context());
+      final classChecks = ClassChecks.create(context());
       expect(classChecks.myRoot.toString(), '@CheckTag("some-tag")');
     });
 
     test('@EnsureTag checks work', () {
-      final ensureTagChecks = new EnsureTagChecks.create(context());
+      final ensureTagChecks = EnsureTagChecks.create(context());
       expect(ensureTagChecks.myRoot.toString(),
           '@EnsureTag("some-other-tag")  @EnsureTag("some-other-tag")');
     });
 
     test('empty class works', () {
-      new Empty.create(context());
+      Empty.create(context());
     });
 
     test('finders work', () {
-      final finders = new Finders.create(context());
+      final finders = Finders.create(context());
       expect(finders.element.toString(), '@ByCss("some-class")');
       expect(finders.secret.toString(), '@ByCss("secret")');
       expect(finders.filtered.toString(),
@@ -57,17 +57,17 @@ void main() {
     });
 
     test('iterators work', () {
-      final inner = new InnerObject.create(context());
+      final inner = InnerObject.create(context());
       expect(inner.innerIterable.toString(), '@ByCss("nested-iterable")');
       expect(inner.innerCheckTagPO.toString(), '@ByTagName("check-tag-po")');
-      final iterables = new Iterables.create(context());
+      final iterables = Iterables.create(context());
       expect(iterables.basics.toString(), '@ByCss("basic")');
       expect(iterables.nested.toString(), '@ByCss("nested")');
       expect(iterables.checkTagPO.toString(), '@ByTagName("check-tag-po")');
     });
 
     test('list works', () async {
-      final list = new Lists.create(context());
+      final list = Lists.create(context());
       expect(await list.basics, hasLength(1));
       expect((await list.basics)[0].toString(), '@ByCss("basic")');
       expect(await list.nested, hasLength(1));
@@ -78,7 +78,7 @@ void main() {
     });
 
     test('list works synchronously', () async {
-      final list = new Lists.create(context());
+      final list = Lists.create(context());
       expect(list.basicsSync, hasLength(1));
       expect(list.basicsSync[0].toString(), '@ByCss("basic")');
       expect(list.nestedSync, hasLength(1));
@@ -90,9 +90,9 @@ void main() {
 
     test('listeners works', () async {
       final root = context();
-      final listener = new DummyListener();
+      final listener = DummyListener();
       root.addListeners([listener]);
-      final nested = new Nested.create(root);
+      final nested = Nested.create(root);
       nested.findersElement.element.toString();
       expect(listener.values, hasLength(2));
       expect(listener.values[0], 'Nested.findersElement');
@@ -100,14 +100,14 @@ void main() {
     });
 
     test('mouse works', () {
-      final mouse = new MouseObject.create(context());
+      final mouse = MouseObject.create(context());
       expect(mouse.mouse.toString(), 'DummyMouse');
     });
 
     test('multiple generated page objects in single file works', () {
-      final a = new A.create(context());
-      final b = new B.create(context());
-      final c = new C.create(context());
+      final a = A.create(context());
+      final b = B.create(context());
+      final c = C.create(context());
 
       expect(a.b.base.toString(), startsWith('@ByCss("b-in-a-class")'));
       expect(c.b.base.toString(), startsWith('@ByCss("b-in-c-class")'));
@@ -118,14 +118,14 @@ void main() {
     });
 
     test('nested singled works', () {
-      final nested = new Nested.create(context());
+      final nested = Nested.create(context());
       final elementString = nested.findersElement.element.toString();
       expect(elementString, startsWith('@ByCss("some-nested-class")'));
       expect(elementString, endsWith('@ByCss("some-class")'));
     });
 
     test('optional parameters work', () {
-      final parameters = new Parameters.create(context());
+      final parameters = Parameters.create(context());
       expect(parameters.testOptionalNamedParam(first: '1'), '1b');
       expect(parameters.testOptionalNamedParam(second: '2'), 'a2');
       expect(parameters.testMixedOptionalNamedParam('x', first: '1'), 'x1b');
@@ -137,15 +137,15 @@ void main() {
     });
 
     test('root works', () {
-      final root = new Root.create(context());
+      final root = Root.create(context());
       expect(root.myRoot.toString(), '');
 
-      final parentRoot = new ParentRoot.create(context());
+      final parentRoot = ParentRoot.create(context());
       expect(parentRoot.root.myRoot.toString(), '@ById("root-id")');
     });
 
     test('unannotated functions work', () {
-      final unannotated = new Unannotated.create(context());
+      final unannotated = Unannotated.create(context());
 
       expect(unannotated.oneParameter('test'), 'private_test');
       expect(unannotated.twoParameters(1, 2), 3);
@@ -155,13 +155,13 @@ void main() {
     });
 
     test('generic classes and functions work', () {
-      final vanillaAsCanBe = new Generics<int>.create(context());
+      final vanillaAsCanBe = Generics<int>.create(context());
       expect(
           vanillaAsCanBe.typeDefParameter(42, (int x) => x.toString()), '42');
     });
 
     test('parameterized getters in classes work', () {
-      final rootPo = new RootPo<String>.create(context());
+      final rootPo = RootPo<String>.create(context());
       expect(rootPo.generics.typeDefParameter(' 42 ', (String x) => x.trim()),
           '42');
       expect(
@@ -171,30 +171,30 @@ void main() {
     });
 
     test('parameterized getter lists in classes work', () {
-      final rootPo = new RootPo<String>.create(context());
-      expect(rootPo.genericsList, new TypeMatcher<List<Generics<String>>>());
+      final rootPo = RootPo<String>.create(context());
+      expect(rootPo.genericsList, TypeMatcher<List<Generics<String>>>());
       expect(rootPo.checkedGenericsList,
-          new TypeMatcher<List<CheckedGenerics<String>>>());
+          TypeMatcher<List<CheckedGenerics<String>>>());
     });
 
     test('generic methods work for singles', () {
-      final generics = new Generics<int>.create(context());
+      final generics = Generics<int>.create(context());
       expect(generics.exampleMethod(5), 5);
     });
 
     test('generic methods work for single with generic lists', () {
-      final generics = new Generics<List<int>>.create(context());
+      final generics = Generics<List<int>>.create(context());
       expect(generics.exampleMethod([5]), [5]);
     });
 
     test('generic methods work for lists of parameters', () {
-      final generics = new GenericPair<int, String>.create(context());
+      final generics = GenericPair<int, String>.create(context());
       expect(generics.exampleMethodMap(5, '6'), containsPair(5, '6'));
     });
 
     test('generic methods work for ridiculously complex generics', () {
       final generics =
-          new GenericPair<List<int>, Map<String, String>>.create(context());
+          GenericPair<List<int>, Map<String, String>>.create(context());
       final key = [5];
       final value = {'a': 'b', 'c': 'd'};
       expect(generics.exampleMethodMap(key, value), containsPair(key, value));
@@ -203,18 +203,18 @@ void main() {
 
   group('mixin', () {
     test('class checks work', () {
-      final classChecks = new ClassChecksUsingMixin.create(context());
+      final classChecks = ClassChecksUsingMixin.create(context());
       expect(classChecks.myRoot.toString(), '@CheckTag("some-tag")');
     });
 
     test('@EnsureTag checks work', () {
-      final ensureTagChecks = new EnsureTagChecksUsingMixin.create(context());
+      final ensureTagChecks = EnsureTagChecksUsingMixin.create(context());
       expect(ensureTagChecks.myRoot.toString(),
           '@EnsureTag("some-other-tag")  @EnsureTag("some-other-tag")');
     });
 
     test('finders work', () {
-      final finders = new FindersUsingMixin.create(context());
+      final finders = FindersUsingMixin.create(context());
       expect(finders.element.toString(), '@ByCss("some-class")');
       expect(finders.secret.toString(), '@ByCss("secret")');
       expect(finders.filtered.toString(),
@@ -224,17 +224,17 @@ void main() {
     });
 
     test('iterators work', () {
-      final inner = new InnerObjectUsingMixin.create(context());
+      final inner = InnerObjectUsingMixin.create(context());
       expect(inner.innerIterable.toString(), '@ByCss("nested-iterable")');
       expect(inner.innerCheckTagPO.toString(), '@ByTagName("check-tag-po")');
-      final iterables = new IterablesUsingMixin.create(context());
+      final iterables = IterablesUsingMixin.create(context());
       expect(iterables.basics.toString(), '@ByCss("basic")');
       expect(iterables.nested.toString(), '@ByCss("nested")');
       expect(iterables.checkTagPO.toString(), '@ByTagName("check-tag-po")');
     });
 
     test('list works', () async {
-      final list = new ListsUsingMixin.create(context());
+      final list = ListsUsingMixin.create(context());
       expect(await list.basics, hasLength(1));
       expect((await list.basics)[0].toString(), '@ByCss("basic")');
       expect(await list.nested, hasLength(1));
@@ -245,7 +245,7 @@ void main() {
     });
 
     test('list works synchronously', () async {
-      final list = new ListsUsingMixin.create(context());
+      final list = ListsUsingMixin.create(context());
       expect(list.basicsSync, hasLength(1));
       expect(list.basicsSync[0].toString(), '@ByCss("basic")');
       expect(list.nestedSync, hasLength(1));
@@ -257,9 +257,9 @@ void main() {
 
     test('listeners works', () async {
       final root = context();
-      final listener = new DummyListener();
+      final listener = DummyListener();
       root.addListeners([listener]);
-      final nested = new NestedUsingMixin.create(root);
+      final nested = NestedUsingMixin.create(root);
       nested.findersElement.element.toString();
       expect(listener.values, hasLength(2));
       expect(listener.values[0], 'NestedMixin.findersElement');
@@ -267,19 +267,19 @@ void main() {
     });
 
     test('mouse works', () {
-      final mouse = new MouseObjectUsingMixin.create(context());
+      final mouse = MouseObjectUsingMixin.create(context());
       expect(mouse.mouse.toString(), 'DummyMouse');
     });
 
     test('nested singled works', () {
-      final nested = new NestedUsingMixin.create(context());
+      final nested = NestedUsingMixin.create(context());
       final elementString = nested.findersElement.element.toString();
       expect(elementString, startsWith('@ByCss("some-nested-class")'));
       expect(elementString, endsWith('@ByCss("some-class")'));
     });
 
     test('optional parameters work', () {
-      final parameters = new ParametersUsingMixin.create(context());
+      final parameters = ParametersUsingMixin.create(context());
       expect(parameters.testOptionalNamedParam(first: '1'), '1b');
       expect(parameters.testOptionalNamedParam(second: '2'), 'a2');
       expect(parameters.testMixedOptionalNamedParam('x', first: '1'), 'x1b');
@@ -291,15 +291,15 @@ void main() {
     });
 
     test('root works', () {
-      final root = new RootUsingMixin.create(context());
+      final root = RootUsingMixin.create(context());
       expect(root.myRoot.toString(), '');
 
-      final parentRoot = new ParentRootUsingMixin.create(context());
+      final parentRoot = ParentRootUsingMixin.create(context());
       expect(parentRoot.root.myRoot.toString(), '@ById("root-id")');
     });
 
     test('unannotated functions work', () {
-      final unannotated = new UnannotatedUsingMixin.create(context());
+      final unannotated = UnannotatedUsingMixin.create(context());
 
       expect(unannotated.oneParameter('test'), 'private_test');
       expect(unannotated.twoParameters(1, 2), 3);
@@ -309,13 +309,13 @@ void main() {
     });
 
     test('generic classes and functions work', () {
-      final vanillaAsCanBe = new GenericsUsingMixin<int>.create(context());
+      final vanillaAsCanBe = GenericsUsingMixin<int>.create(context());
       expect(
           vanillaAsCanBe.typeDefParameter(42, (int x) => x.toString()), '42');
     });
 
     test('parameterized getters in classes work', () {
-      final rootPo = new RootPoUsingMixin<String>.create(context());
+      final rootPo = RootPoUsingMixin<String>.create(context());
       expect(rootPo.generics.typeDefParameter(' 42 ', (String x) => x.trim()),
           '42');
       expect(
@@ -325,30 +325,30 @@ void main() {
     });
 
     test('parameterized getter lists in classes work', () {
-      final rootPo = new RootPoUsingMixin<String>.create(context());
-      expect(rootPo.genericsList, new TypeMatcher<List<Generics<String>>>());
+      final rootPo = RootPoUsingMixin<String>.create(context());
+      expect(rootPo.genericsList, TypeMatcher<List<Generics<String>>>());
       expect(rootPo.checkedGenericsList,
-          new TypeMatcher<List<CheckedGenerics<String>>>());
+          TypeMatcher<List<CheckedGenerics<String>>>());
     });
 
     test('generic methods work for singles', () {
-      final generics = new GenericsUsingMixin<int>.create(context());
+      final generics = GenericsUsingMixin<int>.create(context());
       expect(generics.exampleMethod(5), 5);
     });
 
     test('generic methods work for single with generic lists', () {
-      final generics = new GenericsUsingMixin<List<int>>.create(context());
+      final generics = GenericsUsingMixin<List<int>>.create(context());
       expect(generics.exampleMethod([5]), [5]);
     });
 
     test('generic methods work for lists of parameters', () {
-      final generics = new GenericPairUsingMixin<int, String>.create(context());
+      final generics = GenericPairUsingMixin<int, String>.create(context());
       expect(generics.exampleMethodMap(5, '6'), containsPair(5, '6'));
     });
 
     test('generic methods work for ridiculously complex generics', () {
       final generics =
-          new GenericPairUsingMixin<List<int>, Map<String, String>>.create(
+          GenericPairUsingMixin<List<int>, Map<String, String>>.create(
               context());
       final key = [5];
       final value = {'a': 'b', 'c': 'd'};

--- a/test/data/html_setup.dart
+++ b/test/data/html_setup.dart
@@ -78,7 +78,13 @@ html.Element setUp() {
       <a-custom-tag id="button-2">
         button 2
       </a-custom-tag>
-      <p id="nbsp"> &nbsp; &nbsp; </p>''';
+      <b-custom-tag>
+        <c-custom-tag>C tag inner text</c-custom-tag>
+      </b-custom-tag>
+      <p id="nbsp"> &nbsp; &nbsp; </p>
+      <div id='mouse-top'>top area for mouse events</div>
+      <div id='mouse-center'>center area for mouse events</div>
+      <div id='mouse-bottom'>bottom area for mouse events</div>''';
 
   final templateHtml = '<button id="inner">some <content></content></button>';
 
@@ -100,24 +106,52 @@ html.Element setUp() {
       shadow.setInnerHtml(templateHtml, validator: new NoOpNodeValidator());
     }
   });
+
+  // Get all mouseevent driven div elements and bind them
   final displayedDiv = html.document.getElementById('mouse');
-  displayedDiv.onMouseDown.listen((evt) {
-    displayedDiv.text = displayedDiv.text +
+  final centerDiv = html.document.getElementById('mouse-center');
+  bindMouseEvents(displayedDiv);
+  bindMouseEvents(centerDiv);
+
+  return div;
+}
+
+void bindMouseEvents(html.Element element) {
+  element.onMouseDown.listen((evt) {
+    element.text = element.text +
         " MouseDown: ${evt.client.x}, ${evt.client.y}; "
         "${evt.screen.x}, ${evt.screen.y}";
   });
-  displayedDiv.onMouseUp.listen((evt) {
-    displayedDiv.text = displayedDiv.text +
+  element.onMouseUp.listen((evt) {
+    element.text = element.text +
         " MouseUp: ${evt.client.x}, ${evt.client.y}; "
         "${evt.screen.x}, ${evt.screen.y}";
   });
-  displayedDiv.onMouseMove.listen((evt) {
-    displayedDiv.text = displayedDiv.text +
+  element.onMouseMove.listen((evt) {
+    element.text = element.text +
         " MouseMove: ${evt.client.x}, ${evt.client.y}; "
         "${evt.screen.x}, ${evt.screen.y}";
   });
-
-  return div;
+  element.onMouseLeave.listen((evt) {
+    element.text = element.text +
+        " MouseLeave: ${evt.client.x}, ${evt.client.y}; "
+        "${evt.screen.x}, ${evt.screen.y}";
+  });
+  element.onMouseOut.listen((evt) {
+    element.text = element.text +
+        " MouseOut: ${evt.client.x}, ${evt.client.y}; "
+        "${evt.screen.x}, ${evt.screen.y}";
+  });
+  element.onMouseEnter.listen((evt) {
+    element.text = element.text +
+        " MouseEnter: ${evt.client.x}, ${evt.client.y}; "
+        "${evt.screen.x}, ${evt.screen.y}";
+  });
+  element.onMouseOver.listen((evt) {
+    element.text = element.text +
+        " MouseOver: ${evt.client.x}, ${evt.client.y}; "
+        "${evt.screen.x}, ${evt.screen.y}";
+  });
 }
 
 HtmlPageLoaderElement getRoot() =>

--- a/test/data/html_setup.dart
+++ b/test/data/html_setup.dart
@@ -94,16 +94,16 @@ html.Element setUp() {
   if (results.length == 1) {
     div = results[0];
   } else {
-    div = new html.DivElement();
+    div = html.DivElement();
     div.id = 'testdocument';
     body.append(div);
   }
-  div.setInnerHtml(bodyHtml, validator: new NoOpNodeValidator());
+  div.setInnerHtml(bodyHtml, validator: NoOpNodeValidator());
 
   html.document.getElementsByTagName('a-custom-tag').forEach((element) {
     if (element is html.Element) {
       final shadow = element.createShadowRoot();
-      shadow.setInnerHtml(templateHtml, validator: new NoOpNodeValidator());
+      shadow.setInnerHtml(templateHtml, validator: NoOpNodeValidator());
     }
   });
 
@@ -155,11 +155,11 @@ void bindMouseEvents(html.Element element) {
 }
 
 HtmlPageLoaderElement getRoot() =>
-    new HtmlPageLoaderElement.createFromElement(setUp(),
+    HtmlPageLoaderElement.createFromElement(setUp(),
         externalSyncFn: (Future action()) async {
       await action();
       // Ensure that page has chance to execute before HTML test continues.
-      await new Future.value();
+      await Future.value();
     });
 
 void reset() {

--- a/test/data/webdriver_test_page.html
+++ b/test/data/webdriver_test_page.html
@@ -97,6 +97,9 @@ limitations under the License.
 <a-custom-tag id="button-2">
   button 2
 </a-custom-tag>
+<b-custom-tag>
+  <c-custom-tag>C tag inner text</c-custom-tag>
+</b-custom-tag>
 <p id="nbsp"> &nbsp;
   &nbsp; </p>
 <template id="button-template">

--- a/test/examples/correct/class_checks.g.dart
+++ b/test/examples/correct/class_checks.g.dart
@@ -16,6 +16,9 @@ class $ClassChecks extends ClassChecks with $$ClassChecks {
       : $__root__ = currentContext {
     $__root__.addCheckers([new CheckTag('some-tag')]);
   }
+  factory $ClassChecks.lookup(PageLoaderSource source) =>
+      new $ClassChecks.create(source.byTag('some-tag'));
+  static String get tagName => 'some-tag';
 }
 
 class $$ClassChecks {
@@ -43,6 +46,9 @@ class $EnsureTagChecks extends EnsureTagChecks with $$EnsureTagChecks {
             .createElement(const EnsureTag('some-other-tag'), [], []) {
     $__root__.addCheckers([new EnsureTag('some-other-tag')]);
   }
+  factory $EnsureTagChecks.lookup(PageLoaderSource source) =>
+      new $EnsureTagChecks.create(source.byTag('some-other-tag'));
+  static String get tagName => 'some-other-tag';
 }
 
 class $$EnsureTagChecks {
@@ -70,6 +76,9 @@ class $ClassChecksUsingMixin extends ClassChecksUsingMixin
       : $__root__ = currentContext {
     $__root__.addCheckers([new CheckTag('some-tag')]);
   }
+  factory $ClassChecksUsingMixin.lookup(PageLoaderSource source) =>
+      new $ClassChecksUsingMixin.create(source.byTag('some-tag'));
+  static String get tagName => 'some-tag';
 }
 
 class $$ClassChecksUsingMixin {
@@ -87,6 +96,9 @@ class $EnsureTagChecksUsingMixin extends EnsureTagChecksUsingMixin
             .createElement(const EnsureTag('some-other-tag'), [], []) {
     $__root__.addCheckers([new EnsureTag('some-other-tag')]);
   }
+  factory $EnsureTagChecksUsingMixin.lookup(PageLoaderSource source) =>
+      new $EnsureTagChecksUsingMixin.create(source.byTag('some-other-tag'));
+  static String get tagName => 'some-other-tag';
 }
 
 class $$EnsureTagChecksUsingMixin {

--- a/test/examples/correct/class_checks.g.dart
+++ b/test/examples/correct/class_checks.g.dart
@@ -14,16 +14,16 @@ class $ClassChecks extends ClassChecks with $$ClassChecks {
   PageLoaderElement $__root__;
   $ClassChecks.create(PageLoaderElement currentContext)
       : $__root__ = currentContext {
-    $__root__.addCheckers([new CheckTag('some-tag')]);
+    $__root__.addCheckers([CheckTag('some-tag')]);
   }
   factory $ClassChecks.lookup(PageLoaderSource source) =>
-      new $ClassChecks.create(source.byTag('some-tag'));
+      $ClassChecks.create(source.byTag('some-tag'));
   static String get tagName => 'some-tag';
 }
 
 class $$ClassChecks {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get myRoot {
     for (final __listener in $__root__.listeners) {
@@ -42,18 +42,18 @@ class $$ClassChecks {
 class $EnsureTagChecks extends EnsureTagChecks with $$EnsureTagChecks {
   PageLoaderElement $__root__;
   $EnsureTagChecks.create(PageLoaderElement currentContext)
-      : $__root__ = currentContext
-            .createElement(const EnsureTag('some-other-tag'), [], []) {
-    $__root__.addCheckers([new EnsureTag('some-other-tag')]);
+      : $__root__ =
+            currentContext.createElement(EnsureTag('some-other-tag'), [], []) {
+    $__root__.addCheckers([EnsureTag('some-other-tag')]);
   }
   factory $EnsureTagChecks.lookup(PageLoaderSource source) =>
-      new $EnsureTagChecks.create(source.byTag('some-other-tag'));
+      $EnsureTagChecks.create(source.byTag('some-other-tag'));
   static String get tagName => 'some-other-tag';
 }
 
 class $$EnsureTagChecks {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get myRoot {
     for (final __listener in $__root__.listeners) {
@@ -74,16 +74,16 @@ class $ClassChecksUsingMixin extends ClassChecksUsingMixin
   PageLoaderElement $__root__;
   $ClassChecksUsingMixin.create(PageLoaderElement currentContext)
       : $__root__ = currentContext {
-    $__root__.addCheckers([new CheckTag('some-tag')]);
+    $__root__.addCheckers([CheckTag('some-tag')]);
   }
   factory $ClassChecksUsingMixin.lookup(PageLoaderSource source) =>
-      new $ClassChecksUsingMixin.create(source.byTag('some-tag'));
+      $ClassChecksUsingMixin.create(source.byTag('some-tag'));
   static String get tagName => 'some-tag';
 }
 
 class $$ClassChecksUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -92,18 +92,18 @@ class $EnsureTagChecksUsingMixin extends EnsureTagChecksUsingMixin
     with $$ChecksMixin, $$EnsureTagChecksUsingMixin {
   PageLoaderElement $__root__;
   $EnsureTagChecksUsingMixin.create(PageLoaderElement currentContext)
-      : $__root__ = currentContext
-            .createElement(const EnsureTag('some-other-tag'), [], []) {
-    $__root__.addCheckers([new EnsureTag('some-other-tag')]);
+      : $__root__ =
+            currentContext.createElement(EnsureTag('some-other-tag'), [], []) {
+    $__root__.addCheckers([EnsureTag('some-other-tag')]);
   }
   factory $EnsureTagChecksUsingMixin.lookup(PageLoaderSource source) =>
-      new $EnsureTagChecksUsingMixin.create(source.byTag('some-other-tag'));
+      $EnsureTagChecksUsingMixin.create(source.byTag('some-other-tag'));
   static String get tagName => 'some-other-tag';
 }
 
 class $$EnsureTagChecksUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -111,7 +111,7 @@ class $$EnsureTagChecksUsingMixin {
 
 class $$ChecksMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get myRoot {
     for (final __listener in $__root__.listeners) {

--- a/test/examples/correct/empty.g.dart
+++ b/test/examples/correct/empty.g.dart
@@ -15,6 +15,12 @@ class $Empty extends Empty with $$Empty {
   $Empty.create(PageLoaderElement currentContext) : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Empty.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Empty is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Empty". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$Empty {

--- a/test/examples/correct/empty.g.dart
+++ b/test/examples/correct/empty.g.dart
@@ -25,7 +25,7 @@ class $Empty extends Empty with $$Empty {
 
 class $$Empty {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -33,6 +33,6 @@ class $$Empty {
 
 class $$EmptyMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }

--- a/test/examples/correct/finders.g.dart
+++ b/test/examples/correct/finders.g.dart
@@ -16,6 +16,12 @@ class $Finders extends Finders with $$Finders {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Finders.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Finders is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Finders". Requires @CheckTag annotation in order for "tagName" to be generated.';
   PageLoaderElement get secret {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Finders', 'secret');
@@ -90,6 +96,9 @@ class $CheckTagPO extends CheckTagPO with $$CheckTagPO {
       : $__root__ = currentContext {
     $__root__.addCheckers([new CheckTag('check-tag-po')]);
   }
+  factory $CheckTagPO.lookup(PageLoaderSource source) =>
+      new $CheckTagPO.create(source.byTag('check-tag-po'));
+  static String get tagName => 'check-tag-po';
   String toString() {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('CheckTagPO', 'toString');
@@ -127,6 +136,12 @@ class $FindersUsingMixin extends FindersUsingMixin
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $FindersUsingMixin.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "FindersUsingMixin is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "FindersUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$FindersUsingMixin {

--- a/test/examples/correct/finders.g.dart
+++ b/test/examples/correct/finders.g.dart
@@ -36,13 +36,13 @@ class $Finders extends Finders with $$Finders {
 
 class $$Finders {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get _secret {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Finders', '_secret');
     }
-    final element = $__root__.createElement(const ByCss('secret'), [], []);
+    final element = $__root__.createElement(ByCss('secret'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Finders', '_secret');
@@ -54,7 +54,7 @@ class $$Finders {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Finders', 'element');
     }
-    final element = $__root__.createElement(const ByCss('some-class'), [], []);
+    final element = $__root__.createElement(ByCss('some-class'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Finders', 'element');
@@ -66,8 +66,8 @@ class $$Finders {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Finders', 'filtered');
     }
-    final element = $__root__.createElement(const ByCss('some-other-class'),
-        [const WithAttribute('also-with', 'this-attribute')], []);
+    final element = $__root__.createElement(ByCss('some-other-class'),
+        [WithAttribute('also-with', 'this-attribute')], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Finders', 'filtered');
@@ -79,9 +79,8 @@ class $$Finders {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Finders', 'checkTagPO');
     }
-    final element =
-        $__root__.createElement(const ByTagName('check-tag-po'), [], []);
-    final returnMe = new CheckTagPO.create(element);
+    final element = $__root__.createElement(ByTagName('check-tag-po'), [], []);
+    final returnMe = CheckTagPO.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Finders', 'checkTagPO');
     }
@@ -94,10 +93,10 @@ class $CheckTagPO extends CheckTagPO with $$CheckTagPO {
   PageLoaderElement $__root__;
   $CheckTagPO.create(PageLoaderElement currentContext)
       : $__root__ = currentContext {
-    $__root__.addCheckers([new CheckTag('check-tag-po')]);
+    $__root__.addCheckers([CheckTag('check-tag-po')]);
   }
   factory $CheckTagPO.lookup(PageLoaderSource source) =>
-      new $CheckTagPO.create(source.byTag('check-tag-po'));
+      $CheckTagPO.create(source.byTag('check-tag-po'));
   static String get tagName => 'check-tag-po';
   String toString() {
     for (final __listener in $__root__.listeners) {
@@ -113,7 +112,7 @@ class $CheckTagPO extends CheckTagPO with $$CheckTagPO {
 
 class $$CheckTagPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get _root {
     for (final __listener in $__root__.listeners) {
@@ -146,7 +145,7 @@ class $FindersUsingMixin extends FindersUsingMixin
 
 class $$FindersUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -154,13 +153,13 @@ class $$FindersUsingMixin {
 
 class $$FindersMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get _secret {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('FindersMixin', '_secret');
     }
-    final element = $__root__.createElement(const ByCss('secret'), [], []);
+    final element = $__root__.createElement(ByCss('secret'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('FindersMixin', '_secret');
@@ -172,7 +171,7 @@ class $$FindersMixin {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('FindersMixin', 'element');
     }
-    final element = $__root__.createElement(const ByCss('some-class'), [], []);
+    final element = $__root__.createElement(ByCss('some-class'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('FindersMixin', 'element');
@@ -184,8 +183,8 @@ class $$FindersMixin {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('FindersMixin', 'filtered');
     }
-    final element = $__root__.createElement(const ByCss('some-other-class'),
-        [const WithAttribute('also-with', 'this-attribute')], []);
+    final element = $__root__.createElement(ByCss('some-other-class'),
+        [WithAttribute('also-with', 'this-attribute')], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('FindersMixin', 'filtered');
@@ -197,9 +196,8 @@ class $$FindersMixin {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('FindersMixin', 'checkTagPO');
     }
-    final element =
-        $__root__.createElement(const ByTagName('check-tag-po'), [], []);
-    final returnMe = new CheckTagPO.create(element);
+    final element = $__root__.createElement(ByTagName('check-tag-po'), [], []);
+    final returnMe = CheckTagPO.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('FindersMixin', 'checkTagPO');
     }

--- a/test/examples/correct/generics.g.dart
+++ b/test/examples/correct/generics.g.dart
@@ -16,6 +16,12 @@ class $Generics<T> extends Generics<T> with $$Generics<T> {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Generics.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Generics is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Generics". Requires @CheckTag annotation in order for "tagName" to be generated.';
   String typeDefParameter(T thing, MyGenericTypeDef<T> typeDef) {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Generics', 'typeDefParameter');
@@ -52,6 +58,9 @@ class $CheckedGenerics<T> extends CheckedGenerics<T> with $$CheckedGenerics<T> {
       : $__root__ = currentContext {
     $__root__.addCheckers([new CheckTag('checked-generics')]);
   }
+  factory $CheckedGenerics.lookup(PageLoaderSource source) =>
+      new $CheckedGenerics.create(source.byTag('checked-generics'));
+  static String get tagName => 'checked-generics';
   String typeDefParameter(T thing, MyGenericTypeDef<T> typeDef) {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('CheckedGenerics', 'typeDefParameter');
@@ -77,6 +86,12 @@ class $GenericPair<T, V> extends GenericPair<T, V> with $$GenericPair<T, V> {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $GenericPair.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "GenericPair is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "GenericPair". Requires @CheckTag annotation in order for "tagName" to be generated.';
   Map<T, V> exampleMethodMap<T, V>(T t, V v) {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('GenericPair', 'exampleMethodMap');
@@ -102,6 +117,12 @@ class $RootPo<T> extends RootPo<T> with $$RootPo<T> {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $RootPo.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "RootPo is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "RootPo". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$RootPo<T> {
@@ -168,6 +189,12 @@ class $GenericsUsingMixin<T> extends GenericsUsingMixin<T>
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $GenericsUsingMixin.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "GenericsUsingMixin is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "GenericsUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$GenericsUsingMixin<T> {
@@ -192,6 +219,12 @@ class $GenericPairUsingMixin<T, V> extends GenericPairUsingMixin<T, V>
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $GenericPairUsingMixin.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "GenericPairUsingMixin is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "GenericPairUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$GenericPairUsingMixin<T, V> {
@@ -216,6 +249,12 @@ class $RootPoUsingMixin<T> extends RootPoUsingMixin<T>
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $RootPoUsingMixin.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "RootPoUsingMixin is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "RootPoUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$RootPoUsingMixin<T> {

--- a/test/examples/correct/generics.g.dart
+++ b/test/examples/correct/generics.g.dart
@@ -47,7 +47,7 @@ class $Generics<T> extends Generics<T> with $$Generics<T> {
 
 class $$Generics<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -56,10 +56,10 @@ class $CheckedGenerics<T> extends CheckedGenerics<T> with $$CheckedGenerics<T> {
   PageLoaderElement $__root__;
   $CheckedGenerics.create(PageLoaderElement currentContext)
       : $__root__ = currentContext {
-    $__root__.addCheckers([new CheckTag('checked-generics')]);
+    $__root__.addCheckers([CheckTag('checked-generics')]);
   }
   factory $CheckedGenerics.lookup(PageLoaderSource source) =>
-      new $CheckedGenerics.create(source.byTag('checked-generics'));
+      $CheckedGenerics.create(source.byTag('checked-generics'));
   static String get tagName => 'checked-generics';
   String typeDefParameter(T thing, MyGenericTypeDef<T> typeDef) {
     for (final __listener in $__root__.listeners) {
@@ -75,7 +75,7 @@ class $CheckedGenerics<T> extends CheckedGenerics<T> with $$CheckedGenerics<T> {
 
 class $$CheckedGenerics<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -106,7 +106,7 @@ class $GenericPair<T, V> extends GenericPair<T, V> with $$GenericPair<T, V> {
 
 class $$GenericPair<T, V> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -127,14 +127,14 @@ class $RootPo<T> extends RootPo<T> with $$RootPo<T> {
 
 class $$RootPo<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   Generics<T> get generics {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('RootPo', 'generics');
     }
-    final element = $__root__.createElement(const ByTagName('x'), [], []);
-    final returnMe = new Generics<T>.create(element);
+    final element = $__root__.createElement(ByTagName('x'), [], []);
+    final returnMe = Generics<T>.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('RootPo', 'generics');
     }
@@ -146,8 +146,8 @@ class $$RootPo<T> {
       __listener.startPageObjectMethod('RootPo', 'checkedGenerics');
     }
     final element =
-        $__root__.createElement(const ByTagName('checked-generics'), [], []);
-    final returnMe = new CheckedGenerics<T>.create(element);
+        $__root__.createElement(ByTagName('checked-generics'), [], []);
+    final returnMe = CheckedGenerics<T>.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('RootPo', 'checkedGenerics');
     }
@@ -158,9 +158,9 @@ class $$RootPo<T> {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('RootPo', 'genericsList');
     }
-    final returnMe = new PageObjectList<Generics<T>>(
-        $__root__.createList(const ByTagName('y'), [], []),
-        (PageLoaderElement e) => new Generics<T>.create(e));
+    final returnMe = PageObjectList<Generics<T>>(
+        $__root__.createList(ByTagName('y'), [], []),
+        (PageLoaderElement e) => Generics<T>.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('RootPo', 'genericsList');
     }
@@ -171,9 +171,9 @@ class $$RootPo<T> {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('RootPo', 'checkedGenericsList');
     }
-    final returnMe = new PageObjectList<CheckedGenerics<T>>(
-        $__root__.createList(const ByTagName('checked-generics'), [], []),
-        (PageLoaderElement e) => new CheckedGenerics<T>.create(e));
+    final returnMe = PageObjectList<CheckedGenerics<T>>(
+        $__root__.createList(ByTagName('checked-generics'), [], []),
+        (PageLoaderElement e) => CheckedGenerics<T>.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('RootPo', 'checkedGenericsList');
     }
@@ -199,7 +199,7 @@ class $GenericsUsingMixin<T> extends GenericsUsingMixin<T>
 
 class $$GenericsUsingMixin<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -207,7 +207,7 @@ class $$GenericsUsingMixin<T> {
 
 class $$GenericsMixin<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -229,7 +229,7 @@ class $GenericPairUsingMixin<T, V> extends GenericPairUsingMixin<T, V>
 
 class $$GenericPairUsingMixin<T, V> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -237,7 +237,7 @@ class $$GenericPairUsingMixin<T, V> {
 
 class $$GenericPairMixin<T, V> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -259,7 +259,7 @@ class $RootPoUsingMixin<T> extends RootPoUsingMixin<T>
 
 class $$RootPoUsingMixin<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -267,14 +267,14 @@ class $$RootPoUsingMixin<T> {
 
 class $$RootPoMixin<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   Generics<T> get generics {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('RootPoMixin', 'generics');
     }
-    final element = $__root__.createElement(const ByTagName('x'), [], []);
-    final returnMe = new Generics<T>.create(element);
+    final element = $__root__.createElement(ByTagName('x'), [], []);
+    final returnMe = Generics<T>.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('RootPoMixin', 'generics');
     }
@@ -286,8 +286,8 @@ class $$RootPoMixin<T> {
       __listener.startPageObjectMethod('RootPoMixin', 'checkedGenerics');
     }
     final element =
-        $__root__.createElement(const ByTagName('checked-generics'), [], []);
-    final returnMe = new CheckedGenerics<T>.create(element);
+        $__root__.createElement(ByTagName('checked-generics'), [], []);
+    final returnMe = CheckedGenerics<T>.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('RootPoMixin', 'checkedGenerics');
     }
@@ -298,9 +298,9 @@ class $$RootPoMixin<T> {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('RootPoMixin', 'genericsList');
     }
-    final returnMe = new PageObjectList<Generics<T>>(
-        $__root__.createList(const ByTagName('y'), [], []),
-        (PageLoaderElement e) => new Generics<T>.create(e));
+    final returnMe = PageObjectList<Generics<T>>(
+        $__root__.createList(ByTagName('y'), [], []),
+        (PageLoaderElement e) => Generics<T>.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('RootPoMixin', 'genericsList');
     }
@@ -311,9 +311,9 @@ class $$RootPoMixin<T> {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('RootPoMixin', 'checkedGenericsList');
     }
-    final returnMe = new PageObjectList<CheckedGenerics<T>>(
-        $__root__.createList(const ByTagName('checked-generics'), [], []),
-        (PageLoaderElement e) => new CheckedGenerics<T>.create(e));
+    final returnMe = PageObjectList<CheckedGenerics<T>>(
+        $__root__.createList(ByTagName('checked-generics'), [], []),
+        (PageLoaderElement e) => CheckedGenerics<T>.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('RootPoMixin', 'checkedGenericsList');
     }

--- a/test/examples/correct/iterables.g.dart
+++ b/test/examples/correct/iterables.g.dart
@@ -16,6 +16,12 @@ class $Iterables extends Iterables with $$Iterables {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Iterables.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Iterables is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Iterables". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$Iterables {
@@ -69,6 +75,12 @@ class $InnerObject extends InnerObject with $$InnerObject {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $InnerObject.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "InnerObject is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "InnerObject". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$InnerObject {
@@ -122,6 +134,12 @@ class $IterablesUsingMixin extends IterablesUsingMixin
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $IterablesUsingMixin.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "IterablesUsingMixin is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "IterablesUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$IterablesUsingMixin {
@@ -184,6 +202,12 @@ class $InnerObjectUsingMixin extends InnerObjectUsingMixin
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $InnerObjectUsingMixin.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "InnerObjectUsingMixin is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "InnerObjectUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$InnerObjectUsingMixin {

--- a/test/examples/correct/iterables.g.dart
+++ b/test/examples/correct/iterables.g.dart
@@ -26,14 +26,14 @@ class $Iterables extends Iterables with $$Iterables {
 
 class $$Iterables {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageObjectIterable<PageLoaderElement> get basics {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Iterables', 'basics');
     }
-    final returnMe = new PageObjectIterable<PageLoaderElement>(
-        $__root__.createIterable(const ByCss('basic'), [], []),
+    final returnMe = PageObjectIterable<PageLoaderElement>(
+        $__root__.createIterable(ByCss('basic'), [], []),
         (PageLoaderElement e) => e);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Iterables', 'basics');
@@ -45,9 +45,9 @@ class $$Iterables {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Iterables', 'nested');
     }
-    final returnMe = new PageObjectIterable<InnerObject>(
-        $__root__.createIterable(const ByCss('nested'), [], []),
-        (PageLoaderElement e) => new InnerObject.create(e));
+    final returnMe = PageObjectIterable<InnerObject>(
+        $__root__.createIterable(ByCss('nested'), [], []),
+        (PageLoaderElement e) => InnerObject.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Iterables', 'nested');
     }
@@ -58,9 +58,9 @@ class $$Iterables {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Iterables', 'checkTagPO');
     }
-    final returnMe = new PageObjectIterable<CheckTagPO>(
-        $__root__.createIterable(const ByTagName('check-tag-po'), [], []),
-        (PageLoaderElement e) => new CheckTagPO.create(e));
+    final returnMe = PageObjectIterable<CheckTagPO>(
+        $__root__.createIterable(ByTagName('check-tag-po'), [], []),
+        (PageLoaderElement e) => CheckTagPO.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Iterables', 'checkTagPO');
     }
@@ -85,13 +85,13 @@ class $InnerObject extends InnerObject with $$InnerObject {
 
 class $$InnerObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get single {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('InnerObject', 'single');
     }
-    final element = $__root__.createElement(const ByCss('single'), [], []);
+    final element = $__root__.createElement(ByCss('single'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('InnerObject', 'single');
@@ -103,8 +103,8 @@ class $$InnerObject {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('InnerObject', 'innerIterable');
     }
-    final returnMe = new PageObjectIterable<PageLoaderElement>(
-        $__root__.createIterable(const ByCss('nested-iterable'), [], []),
+    final returnMe = PageObjectIterable<PageLoaderElement>(
+        $__root__.createIterable(ByCss('nested-iterable'), [], []),
         (PageLoaderElement e) => e);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('InnerObject', 'innerIterable');
@@ -116,9 +116,9 @@ class $$InnerObject {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('InnerObject', 'innerCheckTagPO');
     }
-    final returnMe = new PageObjectIterable<CheckTagPO>(
-        $__root__.createIterable(const ByTagName('check-tag-po'), [], []),
-        (PageLoaderElement e) => new CheckTagPO.create(e));
+    final returnMe = PageObjectIterable<CheckTagPO>(
+        $__root__.createIterable(ByTagName('check-tag-po'), [], []),
+        (PageLoaderElement e) => CheckTagPO.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('InnerObject', 'innerCheckTagPO');
     }
@@ -144,7 +144,7 @@ class $IterablesUsingMixin extends IterablesUsingMixin
 
 class $$IterablesUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -152,14 +152,14 @@ class $$IterablesUsingMixin {
 
 class $$IterablesMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageObjectIterable<PageLoaderElement> get basics {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('IterablesMixin', 'basics');
     }
-    final returnMe = new PageObjectIterable<PageLoaderElement>(
-        $__root__.createIterable(const ByCss('basic'), [], []),
+    final returnMe = PageObjectIterable<PageLoaderElement>(
+        $__root__.createIterable(ByCss('basic'), [], []),
         (PageLoaderElement e) => e);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('IterablesMixin', 'basics');
@@ -171,9 +171,9 @@ class $$IterablesMixin {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('IterablesMixin', 'nested');
     }
-    final returnMe = new PageObjectIterable<InnerObjectUsingMixin>(
-        $__root__.createIterable(const ByCss('nested'), [], []),
-        (PageLoaderElement e) => new InnerObjectUsingMixin.create(e));
+    final returnMe = PageObjectIterable<InnerObjectUsingMixin>(
+        $__root__.createIterable(ByCss('nested'), [], []),
+        (PageLoaderElement e) => InnerObjectUsingMixin.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('IterablesMixin', 'nested');
     }
@@ -184,9 +184,9 @@ class $$IterablesMixin {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('IterablesMixin', 'checkTagPO');
     }
-    final returnMe = new PageObjectIterable<CheckTagPO>(
-        $__root__.createIterable(const ByTagName('check-tag-po'), [], []),
-        (PageLoaderElement e) => new CheckTagPO.create(e));
+    final returnMe = PageObjectIterable<CheckTagPO>(
+        $__root__.createIterable(ByTagName('check-tag-po'), [], []),
+        (PageLoaderElement e) => CheckTagPO.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('IterablesMixin', 'checkTagPO');
     }
@@ -212,7 +212,7 @@ class $InnerObjectUsingMixin extends InnerObjectUsingMixin
 
 class $$InnerObjectUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -220,13 +220,13 @@ class $$InnerObjectUsingMixin {
 
 class $$InnerObjectMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get single {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('InnerObjectMixin', 'single');
     }
-    final element = $__root__.createElement(const ByCss('single'), [], []);
+    final element = $__root__.createElement(ByCss('single'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('InnerObjectMixin', 'single');
@@ -238,8 +238,8 @@ class $$InnerObjectMixin {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('InnerObjectMixin', 'innerIterable');
     }
-    final returnMe = new PageObjectIterable<PageLoaderElement>(
-        $__root__.createIterable(const ByCss('nested-iterable'), [], []),
+    final returnMe = PageObjectIterable<PageLoaderElement>(
+        $__root__.createIterable(ByCss('nested-iterable'), [], []),
         (PageLoaderElement e) => e);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('InnerObjectMixin', 'innerIterable');
@@ -251,9 +251,9 @@ class $$InnerObjectMixin {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('InnerObjectMixin', 'innerCheckTagPO');
     }
-    final returnMe = new PageObjectIterable<CheckTagPO>(
-        $__root__.createIterable(const ByTagName('check-tag-po'), [], []),
-        (PageLoaderElement e) => new CheckTagPO.create(e));
+    final returnMe = PageObjectIterable<CheckTagPO>(
+        $__root__.createIterable(ByTagName('check-tag-po'), [], []),
+        (PageLoaderElement e) => CheckTagPO.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('InnerObjectMixin', 'innerCheckTagPO');
     }

--- a/test/examples/correct/list.g.dart
+++ b/test/examples/correct/list.g.dart
@@ -15,6 +15,12 @@ class $Lists extends Lists with $$Lists {
   $Lists.create(PageLoaderElement currentContext) : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Lists.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Lists is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Lists". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$Lists {
@@ -107,6 +113,12 @@ class $InnerListObject extends InnerListObject with $$InnerListObject {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $InnerListObject.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "InnerListObject is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "InnerListObject". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$InnerListObject {
@@ -147,6 +159,12 @@ class $ListsUsingMixin extends ListsUsingMixin
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $ListsUsingMixin.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "ListsUsingMixin is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "ListsUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$ListsUsingMixin {
@@ -248,6 +266,12 @@ class $InnerListObjectUsingMixin extends InnerListObjectUsingMixin
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $InnerListObjectUsingMixin.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "InnerListObjectUsingMixin is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "InnerListObjectUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$InnerListObjectUsingMixin {

--- a/test/examples/correct/list.g.dart
+++ b/test/examples/correct/list.g.dart
@@ -25,14 +25,14 @@ class $Lists extends Lists with $$Lists {
 
 class $$Lists {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   Future<PageObjectList<PageLoaderElement>> get basics async {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Lists', 'basics');
     }
-    final returnMe = new PageObjectList<PageLoaderElement>(
-        $__root__.createList(const ByCss('basic'), [], []),
+    final returnMe = PageObjectList<PageLoaderElement>(
+        $__root__.createList(ByCss('basic'), [], []),
         (PageLoaderElement e) => e);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Lists', 'basics');
@@ -44,9 +44,9 @@ class $$Lists {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Lists', 'nested');
     }
-    final returnMe = new PageObjectList<InnerListObject>(
-        $__root__.createList(const ByCss('nested'), [], []),
-        (PageLoaderElement e) => new InnerListObject.create(e));
+    final returnMe = PageObjectList<InnerListObject>(
+        $__root__.createList(ByCss('nested'), [], []),
+        (PageLoaderElement e) => InnerListObject.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Lists', 'nested');
     }
@@ -57,9 +57,9 @@ class $$Lists {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Lists', 'checkTagPO');
     }
-    final returnMe = new PageObjectList<CheckTagPO>(
-        $__root__.createList(const ByTagName('check-tag-po'), [], []),
-        (PageLoaderElement e) => new CheckTagPO.create(e));
+    final returnMe = PageObjectList<CheckTagPO>(
+        $__root__.createList(ByTagName('check-tag-po'), [], []),
+        (PageLoaderElement e) => CheckTagPO.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Lists', 'checkTagPO');
     }
@@ -70,8 +70,8 @@ class $$Lists {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Lists', 'basicsSync');
     }
-    final returnMe = new PageObjectList<PageLoaderElement>(
-        $__root__.createList(const ByCss('basic'), [], []),
+    final returnMe = PageObjectList<PageLoaderElement>(
+        $__root__.createList(ByCss('basic'), [], []),
         (PageLoaderElement e) => e);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Lists', 'basicsSync');
@@ -83,9 +83,9 @@ class $$Lists {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Lists', 'nestedSync');
     }
-    final returnMe = new PageObjectList<InnerListObject>(
-        $__root__.createList(const ByCss('nested'), [], []),
-        (PageLoaderElement e) => new InnerListObject.create(e));
+    final returnMe = PageObjectList<InnerListObject>(
+        $__root__.createList(ByCss('nested'), [], []),
+        (PageLoaderElement e) => InnerListObject.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Lists', 'nestedSync');
     }
@@ -96,9 +96,9 @@ class $$Lists {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Lists', 'checkTagPOSync');
     }
-    final returnMe = new PageObjectList<CheckTagPO>(
-        $__root__.createList(const ByTagName('check-tag-po'), [], []),
-        (PageLoaderElement e) => new CheckTagPO.create(e));
+    final returnMe = PageObjectList<CheckTagPO>(
+        $__root__.createList(ByTagName('check-tag-po'), [], []),
+        (PageLoaderElement e) => CheckTagPO.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Lists', 'checkTagPOSync');
     }
@@ -123,13 +123,13 @@ class $InnerListObject extends InnerListObject with $$InnerListObject {
 
 class $$InnerListObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get single {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('InnerListObject', 'single');
     }
-    final element = $__root__.createElement(const ByCss('single'), [], []);
+    final element = $__root__.createElement(ByCss('single'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('InnerListObject', 'single');
@@ -141,8 +141,8 @@ class $$InnerListObject {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('InnerListObject', 'innerIterable');
     }
-    final returnMe = new PageObjectList<PageLoaderElement>(
-        $__root__.createList(const ByCss('nested-iterable'), [], []),
+    final returnMe = PageObjectList<PageLoaderElement>(
+        $__root__.createList(ByCss('nested-iterable'), [], []),
         (PageLoaderElement e) => e);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('InnerListObject', 'innerIterable');
@@ -169,7 +169,7 @@ class $ListsUsingMixin extends ListsUsingMixin
 
 class $$ListsUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -177,14 +177,14 @@ class $$ListsUsingMixin {
 
 class $$ListsMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   Future<PageObjectList<PageLoaderElement>> get basics async {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('ListsMixin', 'basics');
     }
-    final returnMe = new PageObjectList<PageLoaderElement>(
-        $__root__.createList(const ByCss('basic'), [], []),
+    final returnMe = PageObjectList<PageLoaderElement>(
+        $__root__.createList(ByCss('basic'), [], []),
         (PageLoaderElement e) => e);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('ListsMixin', 'basics');
@@ -196,9 +196,9 @@ class $$ListsMixin {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('ListsMixin', 'nested');
     }
-    final returnMe = new PageObjectList<InnerListObjectUsingMixin>(
-        $__root__.createList(const ByCss('nested'), [], []),
-        (PageLoaderElement e) => new InnerListObjectUsingMixin.create(e));
+    final returnMe = PageObjectList<InnerListObjectUsingMixin>(
+        $__root__.createList(ByCss('nested'), [], []),
+        (PageLoaderElement e) => InnerListObjectUsingMixin.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('ListsMixin', 'nested');
     }
@@ -209,9 +209,9 @@ class $$ListsMixin {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('ListsMixin', 'checkTagPO');
     }
-    final returnMe = new PageObjectList<CheckTagPO>(
-        $__root__.createList(const ByTagName('check-tag-po'), [], []),
-        (PageLoaderElement e) => new CheckTagPO.create(e));
+    final returnMe = PageObjectList<CheckTagPO>(
+        $__root__.createList(ByTagName('check-tag-po'), [], []),
+        (PageLoaderElement e) => CheckTagPO.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('ListsMixin', 'checkTagPO');
     }
@@ -222,8 +222,8 @@ class $$ListsMixin {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('ListsMixin', 'basicsSync');
     }
-    final returnMe = new PageObjectList<PageLoaderElement>(
-        $__root__.createList(const ByCss('basic'), [], []),
+    final returnMe = PageObjectList<PageLoaderElement>(
+        $__root__.createList(ByCss('basic'), [], []),
         (PageLoaderElement e) => e);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('ListsMixin', 'basicsSync');
@@ -235,9 +235,9 @@ class $$ListsMixin {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('ListsMixin', 'nestedSync');
     }
-    final returnMe = new PageObjectList<InnerListObjectUsingMixin>(
-        $__root__.createList(const ByCss('nested'), [], []),
-        (PageLoaderElement e) => new InnerListObjectUsingMixin.create(e));
+    final returnMe = PageObjectList<InnerListObjectUsingMixin>(
+        $__root__.createList(ByCss('nested'), [], []),
+        (PageLoaderElement e) => InnerListObjectUsingMixin.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('ListsMixin', 'nestedSync');
     }
@@ -248,9 +248,9 @@ class $$ListsMixin {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('ListsMixin', 'checkTagPOSync');
     }
-    final returnMe = new PageObjectList<CheckTagPO>(
-        $__root__.createList(const ByTagName('check-tag-po'), [], []),
-        (PageLoaderElement e) => new CheckTagPO.create(e));
+    final returnMe = PageObjectList<CheckTagPO>(
+        $__root__.createList(ByTagName('check-tag-po'), [], []),
+        (PageLoaderElement e) => CheckTagPO.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('ListsMixin', 'checkTagPOSync');
     }
@@ -276,7 +276,7 @@ class $InnerListObjectUsingMixin extends InnerListObjectUsingMixin
 
 class $$InnerListObjectUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -284,13 +284,13 @@ class $$InnerListObjectUsingMixin {
 
 class $$InnerListObjectMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get single {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('InnerListObjectMixin', 'single');
     }
-    final element = $__root__.createElement(const ByCss('single'), [], []);
+    final element = $__root__.createElement(ByCss('single'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('InnerListObjectMixin', 'single');
@@ -302,8 +302,8 @@ class $$InnerListObjectMixin {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('InnerListObjectMixin', 'innerIterable');
     }
-    final returnMe = new PageObjectList<PageLoaderElement>(
-        $__root__.createList(const ByCss('nested-iterable'), [], []),
+    final returnMe = PageObjectList<PageLoaderElement>(
+        $__root__.createList(ByCss('nested-iterable'), [], []),
         (PageLoaderElement e) => e);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('InnerListObjectMixin', 'innerIterable');

--- a/test/examples/correct/mouse.g.dart
+++ b/test/examples/correct/mouse.g.dart
@@ -26,7 +26,7 @@ class $MouseObject extends MouseObject with $$MouseObject {
 
 class $$MouseObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderMouse get mouse {
     for (final __listener in $__root__.listeners) {
@@ -59,7 +59,7 @@ class $MouseObjectUsingMixin extends MouseObjectUsingMixin
 
 class $$MouseObjectUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -67,7 +67,7 @@ class $$MouseObjectUsingMixin {
 
 class $$MouseObjectMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderMouse get mouse {
     for (final __listener in $__root__.listeners) {

--- a/test/examples/correct/mouse.g.dart
+++ b/test/examples/correct/mouse.g.dart
@@ -16,6 +16,12 @@ class $MouseObject extends MouseObject with $$MouseObject {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $MouseObject.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "MouseObject is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "MouseObject". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$MouseObject {
@@ -43,6 +49,12 @@ class $MouseObjectUsingMixin extends MouseObjectUsingMixin
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $MouseObjectUsingMixin.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "MouseObjectUsingMixin is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "MouseObjectUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$MouseObjectUsingMixin {

--- a/test/examples/correct/multiple_in_file.g.dart
+++ b/test/examples/correct/multiple_in_file.g.dart
@@ -25,15 +25,14 @@ class $A extends A with $$A {
 
 class $$A {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   B get b {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('A', 'b');
     }
-    final element =
-        $__root__.createElement(const ByCss('b-in-a-class'), [], []);
-    final returnMe = new B.create(element);
+    final element = $__root__.createElement(ByCss('b-in-a-class'), [], []);
+    final returnMe = B.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('A', 'b');
     }
@@ -57,13 +56,13 @@ class $B extends B with $$B {
 
 class $$B {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get base {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('B', 'base');
     }
-    final element = $__root__.createElement(const ByCss('base-class'), [], []);
+    final element = $__root__.createElement(ByCss('base-class'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('B', 'base');
@@ -88,15 +87,14 @@ class $C extends C with $$C {
 
 class $$C {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   B get b {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('C', 'b');
     }
-    final element =
-        $__root__.createElement(const ByCss('b-in-c-class'), [], []);
-    final returnMe = new B.create(element);
+    final element = $__root__.createElement(ByCss('b-in-c-class'), [], []);
+    final returnMe = B.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('C', 'b');
     }

--- a/test/examples/correct/multiple_in_file.g.dart
+++ b/test/examples/correct/multiple_in_file.g.dart
@@ -15,6 +15,12 @@ class $A extends A with $$A {
   $A.create(PageLoaderElement currentContext) : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $A.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "A is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "A". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$A {
@@ -41,6 +47,12 @@ class $B extends B with $$B {
   $B.create(PageLoaderElement currentContext) : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $B.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "B is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "B". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$B {
@@ -66,6 +78,12 @@ class $C extends C with $$C {
   $C.create(PageLoaderElement currentContext) : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $C.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "C is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "C". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$C {

--- a/test/examples/correct/nested.g.dart
+++ b/test/examples/correct/nested.g.dart
@@ -26,15 +26,14 @@ class $Nested extends Nested with $$Nested {
 
 class $$Nested {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   Finders get findersElement {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Nested', 'findersElement');
     }
-    final element =
-        $__root__.createElement(const ByCss('some-nested-class'), [], []);
-    final returnMe = new Finders.create(element);
+    final element = $__root__.createElement(ByCss('some-nested-class'), [], []);
+    final returnMe = Finders.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Nested', 'findersElement');
     }
@@ -60,7 +59,7 @@ class $NestedUsingMixin extends NestedUsingMixin
 
 class $$NestedUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -68,15 +67,14 @@ class $$NestedUsingMixin {
 
 class $$NestedMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   FindersUsingMixin get findersElement {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('NestedMixin', 'findersElement');
     }
-    final element =
-        $__root__.createElement(const ByCss('some-nested-class'), [], []);
-    final returnMe = new FindersUsingMixin.create(element);
+    final element = $__root__.createElement(ByCss('some-nested-class'), [], []);
+    final returnMe = FindersUsingMixin.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('NestedMixin', 'findersElement');
     }

--- a/test/examples/correct/nested.g.dart
+++ b/test/examples/correct/nested.g.dart
@@ -16,6 +16,12 @@ class $Nested extends Nested with $$Nested {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Nested.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Nested is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Nested". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$Nested {
@@ -44,6 +50,12 @@ class $NestedUsingMixin extends NestedUsingMixin
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $NestedUsingMixin.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "NestedUsingMixin is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "NestedUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$NestedUsingMixin {

--- a/test/examples/correct/parameters.g.dart
+++ b/test/examples/correct/parameters.g.dart
@@ -16,6 +16,12 @@ class $Parameters extends Parameters with $$Parameters {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Parameters.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Parameters is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Parameters". Requires @CheckTag annotation in order for "tagName" to be generated.';
   String testOptionalPositionalParam(
       [String first = 'a', String second = 'b']) {
     for (final __listener in $__root__.listeners) {
@@ -85,6 +91,12 @@ class $ParametersUsingMixin extends ParametersUsingMixin
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $ParametersUsingMixin.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "ParametersUsingMixin is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "ParametersUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$ParametersUsingMixin {

--- a/test/examples/correct/parameters.g.dart
+++ b/test/examples/correct/parameters.g.dart
@@ -79,7 +79,7 @@ class $Parameters extends Parameters with $$Parameters {
 
 class $$Parameters {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -101,7 +101,7 @@ class $ParametersUsingMixin extends ParametersUsingMixin
 
 class $$ParametersUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -109,6 +109,6 @@ class $$ParametersUsingMixin {
 
 class $$ParametersMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }

--- a/test/examples/correct/root.g.dart
+++ b/test/examples/correct/root.g.dart
@@ -26,14 +26,14 @@ class $ParentRoot extends ParentRoot with $$ParentRoot {
 
 class $$ParentRoot {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   Root get root {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('ParentRoot', 'root');
     }
-    final element = $__root__.createElement(const ById('root-id'), [], []);
-    final returnMe = new Root.create(element);
+    final element = $__root__.createElement(ById('root-id'), [], []);
+    final returnMe = Root.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('ParentRoot', 'root');
     }
@@ -57,7 +57,7 @@ class $Root extends Root with $$Root {
 
 class $$Root {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get myRoot {
     for (final __listener in $__root__.listeners) {
@@ -75,7 +75,7 @@ class $$Root {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Root', 'myId');
     }
-    final element = $__root__.createElement(const ById('some-id'), [], []);
+    final element = $__root__.createElement(ById('some-id'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Root', 'myId');
@@ -102,7 +102,7 @@ class $ParentRootUsingMixin extends ParentRootUsingMixin
 
 class $$ParentRootUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -110,14 +110,14 @@ class $$ParentRootUsingMixin {
 
 class $$ParentRootMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   RootUsingMixin get root {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('ParentRootMixin', 'root');
     }
-    final element = $__root__.createElement(const ById('root-id'), [], []);
-    final returnMe = new RootUsingMixin.create(element);
+    final element = $__root__.createElement(ById('root-id'), [], []);
+    final returnMe = RootUsingMixin.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('ParentRootMixin', 'root');
     }
@@ -143,7 +143,7 @@ class $RootUsingMixin extends RootUsingMixin
 
 class $$RootUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -151,7 +151,7 @@ class $$RootUsingMixin {
 
 class $$RootMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get myRoot {
     for (final __listener in $__root__.listeners) {
@@ -169,7 +169,7 @@ class $$RootMixin {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('RootMixin', 'myId');
     }
-    final element = $__root__.createElement(const ById('some-id'), [], []);
+    final element = $__root__.createElement(ById('some-id'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('RootMixin', 'myId');

--- a/test/examples/correct/root.g.dart
+++ b/test/examples/correct/root.g.dart
@@ -16,6 +16,12 @@ class $ParentRoot extends ParentRoot with $$ParentRoot {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $ParentRoot.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "ParentRoot is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "ParentRoot". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$ParentRoot {
@@ -41,6 +47,12 @@ class $Root extends Root with $$Root {
   $Root.create(PageLoaderElement currentContext) : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Root.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Root is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Root". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$Root {
@@ -80,6 +92,12 @@ class $ParentRootUsingMixin extends ParentRootUsingMixin
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $ParentRootUsingMixin.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "ParentRootUsingMixin is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "ParentRootUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$ParentRootUsingMixin {
@@ -115,6 +133,12 @@ class $RootUsingMixin extends RootUsingMixin
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $RootUsingMixin.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "RootUsingMixin is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "RootUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$RootUsingMixin {

--- a/test/examples/correct/unannotated.g.dart
+++ b/test/examples/correct/unannotated.g.dart
@@ -113,7 +113,7 @@ class $Unannotated extends Unannotated with $$Unannotated {
 
 class $$Unannotated {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -135,7 +135,7 @@ class $UnannotatedUsingMixin extends UnannotatedUsingMixin
 
 class $$UnannotatedUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -143,6 +143,6 @@ class $$UnannotatedUsingMixin {
 
 class $$UnannotatedMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }

--- a/test/examples/correct/unannotated.g.dart
+++ b/test/examples/correct/unannotated.g.dart
@@ -16,6 +16,12 @@ class $Unannotated extends Unannotated with $$Unannotated {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Unannotated.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Unannotated is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Unannotated". Requires @CheckTag annotation in order for "tagName" to be generated.';
   bool get isFieldSet {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Unannotated', 'isFieldSet');
@@ -119,6 +125,12 @@ class $UnannotatedUsingMixin extends UnannotatedUsingMixin
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $UnannotatedUsingMixin.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "UnannotatedUsingMixin is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "UnannotatedUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$UnannotatedUsingMixin {

--- a/test/generation_test_setup/dummy_page_loader_element.dart
+++ b/test/generation_test_setup/dummy_page_loader_element.dart
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import 'dart:async';
+import 'dart:core';
 import 'dart:math';
 
 import 'package:pageloader/pageloader.dart';
@@ -43,7 +44,9 @@ class DummyPageLoaderMouse implements PageLoaderMouse {
 
   @override
   Future<Null> moveTo(PageLoaderElement element, int xOffset, int yOffset,
-          {PageLoaderElement eventTarget}) =>
+          {List<PageLoaderElement> dispatchTo,
+          int stepPixels,
+          Duration duration}) =>
       throw 'can not even';
 }
 
@@ -215,12 +218,18 @@ class DummyPageLoaderElement implements PageLoaderElement {
       throw 'not implemented';
 
   @override
+  DummyPageLoaderElement byTag(String tag) => throw 'not implemented';
+
+  @override
   Future<Null> clear(
           {bool sync: true, bool focusBefore: true, bool blurAfter: true}) =>
       throw 'not implemented';
 
   @override
   Future<Null> click() => throw 'not implemented';
+
+  @override
+  Future<Null> clickOutside() => throw 'not implemented';
 
   @override
   Future<Null> type(String keys,

--- a/test/generation_test_setup/dummy_page_loader_element.dart
+++ b/test/generation_test_setup/dummy_page_loader_element.dart
@@ -58,7 +58,7 @@ class DummyPageLoader extends PageUtils {
   PageLoaderElement byTag(String tag) => throw 'not implemented';
 
   @override
-  PageLoaderMouse get mouse => new DummyPageLoaderMouse();
+  PageLoaderMouse get mouse => DummyPageLoaderMouse();
 }
 
 class DummyPageElementIterable extends PageElementIterable {
@@ -116,7 +116,7 @@ class DummyPageLoaderElement implements PageLoaderElement {
   @override
   PageLoaderElement createElement(
       Finder finder, List<Filter> filter, List<Checker> checkers) {
-    final newElement = new DummyPageLoaderElement();
+    final newElement = DummyPageLoaderElement();
     newElement._finders.addAll(this._finders);
     newElement._finders.add(finder);
     newElement._filter.addAll(filter);
@@ -131,13 +131,13 @@ class DummyPageLoaderElement implements PageLoaderElement {
     final finders = <Finder>[];
     finders.addAll(_finders);
     finders.add(finder);
-    return new DummyPageElementIterable(finders);
+    return DummyPageElementIterable(finders);
   }
 
   @override
   List<PageLoaderElement> createList(
       Finder finder, List<Filter> filter, List<Checker> checkers) {
-    final newElement = new DummyPageLoaderElement();
+    final newElement = DummyPageLoaderElement();
     newElement._finders.addAll(this._finders);
     newElement._finders.add(finder);
     newElement._filter.addAll(filter);
@@ -166,7 +166,7 @@ class DummyPageLoaderElement implements PageLoaderElement {
   dynamic get contextSync => '';
 
   @override
-  PageUtils get utils => new DummyPageLoader();
+  PageUtils get utils => DummyPageLoader();
 
   @override
   DummyPageLoaderElement get shadowRoot => throw 'not implemented';
@@ -190,7 +190,7 @@ class DummyPageLoaderElement implements PageLoaderElement {
   PageLoaderAttributes get properties => throw 'not implemented';
 
   @override
-  final PageLoaderAttributes computedStyle = new DummyPageLoaderAttributes();
+  final PageLoaderAttributes computedStyle = DummyPageLoaderAttributes();
 
   @override
   PageLoaderAttributes get style => throw 'not implemented';

--- a/test/html_constructors_test.dart
+++ b/test/html_constructors_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All rights reserved.
+// Copyright 2018 Google Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,17 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library pageloader.api.page_loader_interface;
+@TestOn('browser')
 
-import 'page_loader_element_interface.dart';
-import 'page_loader_mouse_interface.dart';
-import 'page_loader_source_interface.dart';
+import 'package:test/test.dart';
 
-/// Convenience methods that vary based on environment.
-abstract class PageUtils extends PageLoaderSource {
-  /// Gets the current root element for the DOM. Used to create page objects.
-  PageLoaderElement get root;
+import 'data/html_setup.dart' as html_setup;
+import 'src/constructors.dart' as constructors;
 
-  /// Gets the mouse.
-  PageLoaderMouse get mouse;
+void main() {
+  constructors.runTests(() => html_setup.getRoot());
 }

--- a/test/html_mouse_test.dart
+++ b/test/html_mouse_test.dart
@@ -27,7 +27,7 @@ void main() {
     PageLoaderMouse mouse;
 
     setUp(() {
-      page = new PageForMouseTest.create(html_setup.getRoot());
+      page = PageForMouseTest.create(html_setup.getRoot());
       mouse = page.mouse;
     });
 

--- a/test/matchers_test.dart
+++ b/test/matchers_test.dart
@@ -20,55 +20,55 @@ import 'generation_test_setup/dummy_page_loader_element.dart'
 
 void main() {
   test('exists', () {
-    final context = new DummyPageLoaderElement(exists: true);
-    final po = new DummyPO(context);
+    final context = DummyPageLoaderElement(exists: true);
+    final po = DummyPO(context);
 
     expect(context, exists);
     expect(po, exists);
   });
 
   test('notExists', () {
-    final context = new DummyPageLoaderElement(exists: false);
-    final po = new DummyPO(context);
+    final context = DummyPageLoaderElement(exists: false);
+    final po = DummyPO(context);
 
     expect(context, notExists);
     expect(po, notExists);
   });
 
   test('hasClass', () {
-    final context = new DummyPageLoaderElement(classes: ['foo']);
-    final po = new DummyPO(context);
+    final context = DummyPageLoaderElement(classes: ['foo']);
+    final po = DummyPO(context);
 
     expect(context, hasClass('foo'));
     expect(po, hasClass('foo'));
   });
 
   test('isDisplayed', () {
-    final context = new DummyPageLoaderElement(displayed: true);
-    final po = new DummyPO(context);
+    final context = DummyPageLoaderElement(displayed: true);
+    final po = DummyPO(context);
 
     expect(context, isDisplayed);
     expect(po, isDisplayed);
   });
 
   test('isNotDisplayed', () {
-    final context = new DummyPageLoaderElement(displayed: false);
-    final po = new DummyPO(context);
+    final context = DummyPageLoaderElement(displayed: false);
+    final po = DummyPO(context);
 
     expect(context, isNotDisplayed);
     expect(po, isNotDisplayed);
   });
 
   test('isHidden', () {
-    final context1 = new DummyPageLoaderElement();
+    final context1 = DummyPageLoaderElement();
     (context1.computedStyle as DummyPageLoaderAttributes)['visibility'] =
         'hidden';
-    final context2 = new DummyPageLoaderElement();
+    final context2 = DummyPageLoaderElement();
     (context2.computedStyle as DummyPageLoaderAttributes)['visibility'] =
         'collapse';
 
-    final po1 = new DummyPO(context1);
-    final po2 = new DummyPO(context2);
+    final po1 = DummyPO(context1);
+    final po2 = DummyPO(context2);
 
     expect(context1, isHidden);
     expect(context2, isHidden);
@@ -77,24 +77,24 @@ void main() {
   });
 
   test('isNotHidden', () {
-    final context = new DummyPageLoaderElement();
-    final po = new DummyPO(context);
+    final context = DummyPageLoaderElement();
+    final po = DummyPO(context);
 
     expect(context, isNotHidden);
     expect(po, isNotHidden);
   });
 
   test('isFocused', () {
-    final context = new DummyPageLoaderElement(focused: true);
-    final po = new DummyPO(context);
+    final context = DummyPageLoaderElement(focused: true);
+    final po = DummyPO(context);
 
     expect(context, isFocused);
     expect(po, isFocused);
   });
 
   test('isNotFocused', () {
-    final context = new DummyPageLoaderElement(focused: false);
-    final po = new DummyPO(context);
+    final context = DummyPageLoaderElement(focused: false);
+    final po = DummyPO(context);
 
     expect(context, isNotFocused);
     expect(po, isNotFocused);

--- a/test/mocks/annotations.dart
+++ b/test/mocks/annotations.dart
@@ -16,7 +16,7 @@ library pageloader.annotations;
 
 import '/test/root/path/annotation_interfaces.dart';
 
-const root = const _Root();
+const root = _Root();
 
 class _Root {
   const _Root();
@@ -25,7 +25,7 @@ class _Root {
   String toString() => '@root';
 }
 
-const Mouse = const _Mouse();
+const Mouse = _Mouse();
 
 class _Mouse {
   const _Mouse();

--- a/test/mocks/sdk.dart
+++ b/test/mocks/sdk.dart
@@ -22,23 +22,23 @@ import 'package:analyzer/src/summary/idl.dart' show PackageBundle;
 import 'package:analyzer/src/summary/summary_file_builder.dart';
 
 const String librariesContent = r'''
-const Map<String, LibraryInfo> libraries = const {
-  "async": const LibraryInfo("async/async.dart"),
-  "collection": const LibraryInfo("collection/collection.dart"),
-  "convert": const LibraryInfo("convert/convert.dart"),
-  "core": const LibraryInfo("core/core.dart"),
-  "html": const LibraryInfo(
+const Map<String, LibraryInfo> libraries = {
+  "async": LibraryInfo("async/async.dart"),
+  "collection": LibraryInfo("collection/collection.dart"),
+  "convert": LibraryInfo("convert/convert.dart"),
+  "core": LibraryInfo("core/core.dart"),
+  "html": LibraryInfo(
     "html/dartium/html_dartium.dart",
     dart2jsPath: "html/dart2js/html_dart2js.dart"),
-  "math": const LibraryInfo("math/math.dart"),
-  "_foreign_helper": const LibraryInfo("_internal/js_runtime/lib/foreign_helper.dart"),
+  "math": LibraryInfo("math/math.dart"),
+  "_foreign_helper": LibraryInfo("_internal/js_runtime/lib/foreign_helper.dart"),
 };
 ''';
 
 const String sdkRoot = '/sdk';
 
 const _MockSdkLibrary _LIB_ASYNC =
-    const _MockSdkLibrary('dart:async', '$sdkRoot/lib/async/async.dart', '''
+    _MockSdkLibrary('dart:async', '$sdkRoot/lib/async/async.dart', '''
 library dart.async;
 
 import 'dart:math';
@@ -67,7 +67,7 @@ abstract class Completer<T> {
   void completeError(Object error, [StackTrace stackTrace]);
   bool get isCompleted;
 }
-''', const <String, String>{
+''', <String, String>{
   '$sdkRoot/lib/async/stream.dart': r'''
 part of dart.async;
 abstract class Stream<T> {
@@ -95,15 +95,15 @@ abstract class StreamTransformer<S, T> {}
 '''
 });
 
-const _MockSdkLibrary _LIB_COLLECTION = const _MockSdkLibrary(
+const _MockSdkLibrary _LIB_COLLECTION = _MockSdkLibrary(
     'dart:collection', '$sdkRoot/lib/collection/collection.dart', '''
 library dart.collection;
 
 abstract class HashMap<K, V> implements Map<K, V> {}
 ''');
 
-const _MockSdkLibrary _LIB_CONVERT = const _MockSdkLibrary(
-    'dart:convert', '$sdkRoot/lib/convert/convert.dart', '''
+const _MockSdkLibrary _LIB_CONVERT =
+    _MockSdkLibrary('dart:convert', '$sdkRoot/lib/convert/convert.dart', '''
 library dart.convert;
 
 import 'dart:async';
@@ -113,7 +113,7 @@ class JsonDecoder extends Converter<String, Object> {}
 ''');
 
 const _MockSdkLibrary _LIB_CORE =
-    const _MockSdkLibrary('dart:core', '$sdkRoot/lib/core/core.dart', '''
+    _MockSdkLibrary('dart:core', '$sdkRoot/lib/core/core.dart', '''
 library dart.core;
 
 import 'dart:async';
@@ -299,7 +299,7 @@ class Deprecated extends Object {
   final String expires;
   const Deprecated(this.expires);
 }
-const Object deprecated = const Deprecated("next release");
+const Object deprecated = Deprecated("next release");
 
 class Iterator<E> {
   bool moveNext();
@@ -355,10 +355,10 @@ external bool identical(Object a, Object b);
 void print(Object object) {}
 
 class _Proxy { const _Proxy(); }
-const Object proxy = const _Proxy();
+const Object proxy = _Proxy();
 
 class _Override { const _Override(); }
-const Object override = const _Override();
+const Object override = _Override();
 
 class _CompileTimeError {
   final String _errorMsg;
@@ -370,7 +370,7 @@ class _ConstantExpressionError {
 }
 ''');
 
-const _MockSdkLibrary _LIB_FOREIGN_HELPER = const _MockSdkLibrary(
+const _MockSdkLibrary _LIB_FOREIGN_HELPER = _MockSdkLibrary(
     'dart:_foreign_helper',
     '$sdkRoot/lib/_foreign_helper/_foreign_helper.dart', '''
 library dart._foreign_helper;
@@ -380,13 +380,13 @@ JS(String typeDescription, String codeTemplate,
 {}
 ''');
 
-const _MockSdkLibrary _LIB_HTML_DART2JS = const _MockSdkLibrary(
+const _MockSdkLibrary _LIB_HTML_DART2JS = _MockSdkLibrary(
     'dart:html', '$sdkRoot/lib/html/dart2js/html_dart2js.dart', '''
 library dart.html;
 class HtmlElement {}
 ''');
 
-const _MockSdkLibrary _LIB_HTML_DARTIUM = const _MockSdkLibrary(
+const _MockSdkLibrary _LIB_HTML_DARTIUM = _MockSdkLibrary(
     'dart:html', '$sdkRoot/lib/html/dartium/html_dartium.dart', '''
 library dart.dom.html;
 
@@ -418,14 +418,13 @@ abstract class class CanvasRenderingContext2D {}
 Element query(String relativeSelectors) => null;
 ''');
 
-const _MockSdkLibrary _LIB_INTERCEPTORS = const _MockSdkLibrary(
-    'dart:_interceptors',
+const _MockSdkLibrary _LIB_INTERCEPTORS = _MockSdkLibrary('dart:_interceptors',
     '$sdkRoot/lib/_internal/js_runtime/lib/interceptors.dart', '''
 library dart._interceptors;
 ''');
 
 const _MockSdkLibrary _LIB_MATH =
-    const _MockSdkLibrary('dart:math', '$sdkRoot/lib/math/math.dart', '''
+    _MockSdkLibrary('dart:math', '$sdkRoot/lib/math/math.dart', '''
 library dart.math;
 
 const double E = 2.718281828459045;
@@ -445,7 +444,7 @@ class Random {
 }
 ''');
 
-const List<SdkLibrary> _LIBRARIES = const [
+const List<SdkLibrary> _LIBRARIES = [
   _LIB_CORE,
   _LIB_ASYNC,
   _LIB_COLLECTION,
@@ -458,7 +457,7 @@ const List<SdkLibrary> _LIBRARIES = const [
 ];
 
 class MockSdk implements DartSdk {
-  static const Map<String, String> FULL_URI_MAP = const {
+  static const Map<String, String> FULL_URI_MAP = {
     "dart:core": "$sdkRoot/lib/core/core.dart",
     "dart:html": "$sdkRoot/lib/html/dartium/html_dartium.dart",
     "dart:async": "$sdkRoot/lib/async/async.dart",
@@ -471,7 +470,7 @@ class MockSdk implements DartSdk {
     "dart:math": "$sdkRoot/lib/math/math.dart"
   };
 
-  static const Map<String, String> NO_ASYNC_URI_MAP = const {
+  static const Map<String, String> NO_ASYNC_URI_MAP = {
     "dart:core": "$sdkRoot/lib/core/core.dart",
   };
 
@@ -492,7 +491,7 @@ class MockSdk implements DartSdk {
       {bool generateSummaryFiles: false,
       bool dartAsync: true,
       resource.MemoryResourceProvider resourceProvider})
-      : provider = resourceProvider ?? new resource.MemoryResourceProvider(),
+      : provider = resourceProvider ?? resource.MemoryResourceProvider(),
         sdkLibraries = dartAsync ? _LIBRARIES : [_LIB_CORE],
         uriMap = dartAsync ? FULL_URI_MAP : NO_ASYNC_URI_MAP {
     for (_MockSdkLibrary library in sdkLibraries) {
@@ -517,15 +516,15 @@ class MockSdk implements DartSdk {
   @override
   AnalysisContextImpl get context {
     if (_analysisContext == null) {
-      _analysisContext = new _SdkAnalysisContext(this);
-      final factory = new SourceFactory([new DartUriResolver(this)]);
+      _analysisContext = _SdkAnalysisContext(this);
+      final factory = SourceFactory([DartUriResolver(this)]);
       _analysisContext.sourceFactory = factory;
     }
     return _analysisContext;
   }
 
   @override
-  String get sdkVersion => throw new UnimplementedError();
+  String get sdkVersion => throw UnimplementedError();
 
   @override
   List<String> get uris =>
@@ -576,7 +575,7 @@ class MockSdk implements DartSdk {
       } else {
         bytes = _computeLinkedBundleBytes();
       }
-      _bundle = new PackageBundle.fromBuffer(bytes);
+      _bundle = PackageBundle.fromBuffer(bytes);
     }
     return _bundle;
   }
@@ -597,8 +596,7 @@ class MockSdk implements DartSdk {
     if (path != null) {
       final file =
           provider.getResource(provider.convertPath(path)) as resource.File;
-      final uri =
-          new Uri(scheme: 'dart', path: dartUri.substring('dart:'.length));
+      final uri = Uri(scheme: 'dart', path: dartUri.substring('dart:'.length));
       return file.createSource(uri);
     }
     // If we reach here then we tried to use a dartUri that's not in the
@@ -623,7 +621,7 @@ class MockSdk implements DartSdk {
     final librarySources = sdkLibraries
         .map((SdkLibrary library) => mapDartUri(library.shortName))
         .toList();
-    return new SummaryBuilder(
+    return SummaryBuilder(
             librarySources, context, context.analysisOptions.strongMode)
         .build();
   }
@@ -643,25 +641,25 @@ class _MockSdkLibrary implements SdkLibrary {
       [this.parts = const <String, String>{}]);
 
   @override
-  String get category => throw new UnimplementedError();
+  String get category => throw UnimplementedError();
 
   @override
-  bool get isDart2JsLibrary => throw new UnimplementedError();
+  bool get isDart2JsLibrary => throw UnimplementedError();
 
   @override
-  bool get isDocumented => throw new UnimplementedError();
+  bool get isDocumented => throw UnimplementedError();
 
   @override
-  bool get isImplementation => throw new UnimplementedError();
+  bool get isImplementation => throw UnimplementedError();
 
   @override
   bool get isInternal => shortName.startsWith('dart:_');
 
   @override
-  bool get isShared => throw new UnimplementedError();
+  bool get isShared => throw UnimplementedError();
 
   @override
-  bool get isVmLibrary => throw new UnimplementedError();
+  bool get isVmLibrary => throw UnimplementedError();
 }
 
 /// An [AnalysisContextImpl] that only contains sources for a Dart SDK.
@@ -675,7 +673,7 @@ class _SdkAnalysisContext extends AnalysisContextImpl {
     if (factory == null) {
       return super.createCacheFromSourceFactory(factory);
     }
-    return new AnalysisCache(
+    return AnalysisCache(
         <CachePartition>[AnalysisEngine.instance.partitionManager.forSdk(sdk)]);
   }
 }

--- a/test/setup/io_config.dart
+++ b/test/setup/io_config.dart
@@ -46,7 +46,7 @@ String testPagePath() {
   final testPagePath =
       path.absolute('test', 'data', 'webdriver_test_page.html');
   if (!FileSystemEntity.isFileSync(testPagePath)) {
-    throw new Exception('Could not find the test file at "$testPagePath".'
+    throw Exception('Could not find the test file at "$testPagePath".'
         ' Make sure you are running tests from the root of the project.');
   }
   return path.toUri(testPagePath).toString();

--- a/test/setup/webdriver_environment.dart
+++ b/test/setup/webdriver_environment.dart
@@ -25,7 +25,7 @@ class WebDriverEnvironment {
 
   Future setUp() async {
     driver = webtest.createTestDriver();
-    _loader = new WebDriverPageUtils(driver);
+    _loader = WebDriverPageUtils(driver);
     driver.get(webtest.testPagePath());
   }
 

--- a/test/src/annotations.dart
+++ b/test/src/annotations.dart
@@ -23,20 +23,20 @@ typedef PageLoaderElement GetNewContext();
 void runTests(GetNewContext contextGenerator) {
   group('annotations', () {
     test('CheckTag annotation', () async {
-      final base = new BaseObject.create(contextGenerator());
+      final base = BaseObject.create(contextGenerator());
       expect(base.table.table.name, 'table');
       expect(base.tableUsingCheckedTag.table.name, base.table.table.name);
       await verifyRows(base.table.rows);
     });
 
     test('EnsureTag annotation', () async {
-      final base = new BaseEnsureObject.create(contextGenerator());
+      final base = BaseEnsureObject.create(contextGenerator());
       expect(base.table.table.name, 'table');
       await verifyRows(base.table.rows);
     });
 
     test('CheckTag annotation fails as expected', () async {
-      final base = new BaseObject.create(contextGenerator());
+      final base = BaseObject.create(contextGenerator());
       try {
         base.badTable.table.name;
         fail('Expected to throw on bad @CheckTag');
@@ -47,7 +47,7 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('EnsureTag annotation fails as expected', () async {
-      final base = new BaseEnsureObject.create(contextGenerator());
+      final base = BaseEnsureObject.create(contextGenerator());
       try {
         base.badTable.table.name;
         fail('Expected to throw on bad @EnsureTag');
@@ -57,29 +57,29 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('Global top ', () async {
-      final base = new BaseObject.create(contextGenerator());
+      final base = BaseObject.create(contextGenerator());
       expect(base.globalTable.name, 'table');
     });
 
     test('Global nested', () async {
-      final base = new BaseObject.create(contextGenerator());
+      final base = BaseObject.create(contextGenerator());
       expect(base.table.globalTable.name, 'table');
     });
 
     test('WithAttribute', () async {
-      final page = new PageForWithAttributeTest.create(contextGenerator());
+      final page = PageForWithAttributeTest.create(contextGenerator());
       expect(page.element.attributes['type'], 'checkbox');
     });
 
     test('WithClass', () async {
-      final page = new PageForWithClassTest.create(contextGenerator());
+      final page = PageForWithClassTest.create(contextGenerator());
       expect(page.element.attributes['type'], 'checkbox');
       expect(page.element.classes,
           unorderedEquals(['with-class-test', 'class1', 'class2']));
     });
 
     test('DebugId', () async {
-      final page = new DebugIds.create(contextGenerator());
+      final page = DebugIds.create(contextGenerator());
       expect(page.option1.innerText, 'option 1');
       expect(page.option2.innerText, 'option 2');
       expect(page.option3.innerText, 'option 3');
@@ -91,13 +91,13 @@ void runTests(GetNewContext contextGenerator) {
 
   group('custom annotations', () {
     test('CheckTag annotation', () async {
-      final base = new PseudoBaseObject.create(contextGenerator());
+      final base = PseudoBaseObject.create(contextGenerator());
       expect(base.table.table.name, 'table');
       await verifyRows(base.table.rows);
     });
 
     test('CheckTag annotation fails as expected', () async {
-      final base = new PseudoBaseObject.create(contextGenerator());
+      final base = PseudoBaseObject.create(contextGenerator());
       try {
         base.badTable.table.name;
         fail('Expected to throw on bad @CheckTag');
@@ -108,12 +108,12 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('Global top ', () async {
-      final base = new PseudoBaseObject.create(contextGenerator());
+      final base = PseudoBaseObject.create(contextGenerator());
       expect(base.globalTable.name, 'table');
     });
 
     test('Global nested', () async {
-      final base = new PseudoBaseObject.create(contextGenerator());
+      final base = PseudoBaseObject.create(contextGenerator());
       expect(base.table.globalTable.name, 'table');
     });
   });
@@ -130,7 +130,7 @@ abstract class BaseObject {
   @ByCheckTag()
   TableForCheckTag get tableUsingCheckedTag;
 
-  @Global(const ByTagName('table'))
+  @Global(ByTagName('table'))
   PageLoaderElement get globalTable;
 
   @ByTagName('table')
@@ -146,7 +146,7 @@ abstract class PseudoBaseObject {
   @PseudoByTagName('table')
   TableForCheckTag get table;
 
-  @Global(const PseudoByTagName('table'))
+  @Global(PseudoByTagName('table'))
   PageLoaderElement get globalTable;
 
   @PseudoByTagName('table')
@@ -163,7 +163,7 @@ abstract class TableForCheckTag {
   @root
   PageLoaderElement get table;
 
-  @Global(const ByTagName('table'))
+  @Global(ByTagName('table'))
   PageLoaderElement get globalTable;
 
   @ByTagName('tr')

--- a/test/src/annotations.g.dart
+++ b/test/src/annotations.g.dart
@@ -26,14 +26,14 @@ class $BaseObject extends BaseObject with $$BaseObject {
 
 class $$BaseObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   TableForCheckTag get table {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('BaseObject', 'table');
     }
-    final element = $__root__.createElement(const ByTagName('table'), [], []);
-    final returnMe = new TableForCheckTag.create(element);
+    final element = $__root__.createElement(ByTagName('table'), [], []);
+    final returnMe = TableForCheckTag.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('BaseObject', 'table');
     }
@@ -44,8 +44,8 @@ class $$BaseObject {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('BaseObject', 'tableUsingCheckedTag');
     }
-    final element = $__root__.createElement(const ByTagName('table'), [], []);
-    final returnMe = new TableForCheckTag.create(element);
+    final element = $__root__.createElement(ByTagName('table'), [], []);
+    final returnMe = TableForCheckTag.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('BaseObject', 'tableUsingCheckedTag');
     }
@@ -56,8 +56,7 @@ class $$BaseObject {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('BaseObject', 'globalTable');
     }
-    final element =
-        $__root__.createElement(const Global(const ByTagName('table')), [], []);
+    final element = $__root__.createElement(Global(ByTagName('table')), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('BaseObject', 'globalTable');
@@ -69,8 +68,8 @@ class $$BaseObject {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('BaseObject', 'badTable');
     }
-    final element = $__root__.createElement(const ByTagName('table'), [], []);
-    final returnMe = new CheckTagFails.create(element);
+    final element = $__root__.createElement(ByTagName('table'), [], []);
+    final returnMe = CheckTagFails.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('BaseObject', 'badTable');
     }
@@ -95,15 +94,14 @@ class $PseudoBaseObject extends PseudoBaseObject with $$PseudoBaseObject {
 
 class $$PseudoBaseObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   TableForCheckTag get table {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PseudoBaseObject', 'table');
     }
-    final element =
-        $__root__.createElement(const PseudoByTagName('table'), [], []);
-    final returnMe = new TableForCheckTag.create(element);
+    final element = $__root__.createElement(PseudoByTagName('table'), [], []);
+    final returnMe = TableForCheckTag.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PseudoBaseObject', 'table');
     }
@@ -114,8 +112,8 @@ class $$PseudoBaseObject {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PseudoBaseObject', 'globalTable');
     }
-    final element = $__root__
-        .createElement(const Global(const PseudoByTagName('table')), [], []);
+    final element =
+        $__root__.createElement(Global(PseudoByTagName('table')), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PseudoBaseObject', 'globalTable');
@@ -127,9 +125,8 @@ class $$PseudoBaseObject {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PseudoBaseObject', 'badTable');
     }
-    final element =
-        $__root__.createElement(const PseudoByTagName('table'), [], []);
-    final returnMe = new CheckTagFails.create(element);
+    final element = $__root__.createElement(PseudoByTagName('table'), [], []);
+    final returnMe = CheckTagFails.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PseudoBaseObject', 'badTable');
     }
@@ -142,16 +139,16 @@ class $TableForCheckTag extends TableForCheckTag with $$TableForCheckTag {
   PageLoaderElement $__root__;
   $TableForCheckTag.create(PageLoaderElement currentContext)
       : $__root__ = currentContext {
-    $__root__.addCheckers([new CheckTag('table')]);
+    $__root__.addCheckers([CheckTag('table')]);
   }
   factory $TableForCheckTag.lookup(PageLoaderSource source) =>
-      new $TableForCheckTag.create(source.byTag('table'));
+      $TableForCheckTag.create(source.byTag('table'));
   static String get tagName => 'table';
 }
 
 class $$TableForCheckTag {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get table {
     for (final __listener in $__root__.listeners) {
@@ -169,8 +166,7 @@ class $$TableForCheckTag {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('TableForCheckTag', 'globalTable');
     }
-    final element =
-        $__root__.createElement(const Global(const ByTagName('table')), [], []);
+    final element = $__root__.createElement(Global(ByTagName('table')), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('TableForCheckTag', 'globalTable');
@@ -182,9 +178,9 @@ class $$TableForCheckTag {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('TableForCheckTag', 'rows');
     }
-    final returnMe = new PageObjectIterable<Row>(
-        $__root__.createIterable(const ByTagName('tr'), [], []),
-        (PageLoaderElement e) => new Row.create(e));
+    final returnMe = PageObjectIterable<Row>(
+        $__root__.createIterable(ByTagName('tr'), [], []),
+        (PageLoaderElement e) => Row.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('TableForCheckTag', 'rows');
     }
@@ -209,14 +205,14 @@ class $BaseEnsureObject extends BaseEnsureObject with $$BaseEnsureObject {
 
 class $$BaseEnsureObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   TableForEnsureTag get table {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('BaseEnsureObject', 'table');
     }
-    final element = $__root__.createElement(const ByTagName('table'), [], []);
-    final returnMe = new TableForEnsureTag.create(element);
+    final element = $__root__.createElement(ByTagName('table'), [], []);
+    final returnMe = TableForEnsureTag.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('BaseEnsureObject', 'table');
     }
@@ -227,8 +223,8 @@ class $$BaseEnsureObject {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('BaseEnsureObject', 'badTable');
     }
-    final element = $__root__.createElement(const ByTagName('table'), [], []);
-    final returnMe = new EnsureTagFails.create(element);
+    final element = $__root__.createElement(ByTagName('table'), [], []);
+    final returnMe = EnsureTagFails.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('BaseEnsureObject', 'badTable');
     }
@@ -240,18 +236,17 @@ class $$BaseEnsureObject {
 class $TableForEnsureTag extends TableForEnsureTag with $$TableForEnsureTag {
   PageLoaderElement $__root__;
   $TableForEnsureTag.create(PageLoaderElement currentContext)
-      : $__root__ =
-            currentContext.createElement(const EnsureTag('table'), [], []) {
-    $__root__.addCheckers([new EnsureTag('table')]);
+      : $__root__ = currentContext.createElement(EnsureTag('table'), [], []) {
+    $__root__.addCheckers([EnsureTag('table')]);
   }
   factory $TableForEnsureTag.lookup(PageLoaderSource source) =>
-      new $TableForEnsureTag.create(source.byTag('table'));
+      $TableForEnsureTag.create(source.byTag('table'));
   static String get tagName => 'table';
 }
 
 class $$TableForEnsureTag {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get table {
     for (final __listener in $__root__.listeners) {
@@ -269,9 +264,9 @@ class $$TableForEnsureTag {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('TableForEnsureTag', 'rows');
     }
-    final returnMe = new PageObjectIterable<Row>(
-        $__root__.createIterable(const ByTagName('tr'), [], []),
-        (PageLoaderElement e) => new Row.create(e));
+    final returnMe = PageObjectIterable<Row>(
+        $__root__.createIterable(ByTagName('tr'), [], []),
+        (PageLoaderElement e) => Row.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('TableForEnsureTag', 'rows');
     }
@@ -284,16 +279,16 @@ class $CheckTagFails extends CheckTagFails with $$CheckTagFails {
   PageLoaderElement $__root__;
   $CheckTagFails.create(PageLoaderElement currentContext)
       : $__root__ = currentContext {
-    $__root__.addCheckers([new CheckTag('inconceivable')]);
+    $__root__.addCheckers([CheckTag('inconceivable')]);
   }
   factory $CheckTagFails.lookup(PageLoaderSource source) =>
-      new $CheckTagFails.create(source.byTag('inconceivable'));
+      $CheckTagFails.create(source.byTag('inconceivable'));
   static String get tagName => 'inconceivable';
 }
 
 class $$CheckTagFails {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get table {
     for (final __listener in $__root__.listeners) {
@@ -312,18 +307,18 @@ class $$CheckTagFails {
 class $EnsureTagFails extends EnsureTagFails with $$EnsureTagFails {
   PageLoaderElement $__root__;
   $EnsureTagFails.create(PageLoaderElement currentContext)
-      : $__root__ = currentContext
-            .createElement(const EnsureTag('inconceivable'), [], []) {
-    $__root__.addCheckers([new EnsureTag('inconceivable')]);
+      : $__root__ =
+            currentContext.createElement(EnsureTag('inconceivable'), [], []) {
+    $__root__.addCheckers([EnsureTag('inconceivable')]);
   }
   factory $EnsureTagFails.lookup(PageLoaderSource source) =>
-      new $EnsureTagFails.create(source.byTag('inconceivable'));
+      $EnsureTagFails.create(source.byTag('inconceivable'));
   static String get tagName => 'inconceivable';
 }
 
 class $$EnsureTagFails {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get table {
     for (final __listener in $__root__.listeners) {
@@ -356,14 +351,14 @@ class $PageForWithAttributeTest extends PageForWithAttributeTest
 
 class $$PageForWithAttributeTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get element {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForWithAttributeTest', 'element');
     }
-    final element = $__root__.createElement(const ByTagName('input'),
-        [const WithAttribute('type', 'checkbox')], []);
+    final element = $__root__.createElement(
+        ByTagName('input'), [WithAttribute('type', 'checkbox')], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForWithAttributeTest', 'element');
@@ -390,14 +385,14 @@ class $PageForWithClassTest extends PageForWithClassTest
 
 class $$PageForWithClassTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get element {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForWithClassTest', 'element');
     }
-    final element = $__root__.createElement(
-        const ByTagName('input'), [const WithClass('with-class-test')], []);
+    final element = $__root__
+        .createElement(ByTagName('input'), [WithClass('with-class-test')], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForWithClassTest', 'element');
@@ -423,13 +418,13 @@ class $DebugIds extends DebugIds with $$DebugIds {
 
 class $$DebugIds {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get option1 {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('DebugIds', 'option1');
     }
-    final element = $__root__.createElement(const ByDebugId('option1'), [], []);
+    final element = $__root__.createElement(ByDebugId('option1'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('DebugIds', 'option1');
@@ -441,7 +436,7 @@ class $$DebugIds {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('DebugIds', 'option2');
     }
-    final element = $__root__.createElement(const ByDebugId('option2'), [], []);
+    final element = $__root__.createElement(ByDebugId('option2'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('DebugIds', 'option2');
@@ -453,7 +448,7 @@ class $$DebugIds {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('DebugIds', 'option3');
     }
-    final element = $__root__.createElement(const ByDebugId('option3'), [], []);
+    final element = $__root__.createElement(ByDebugId('option3'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('DebugIds', 'option3');
@@ -465,8 +460,8 @@ class $$DebugIds {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('DebugIds', 'usePlain');
     }
-    final element = $__root__
-        .createElement(const ByDebugId('option1', usePlain: true), [], []);
+    final element =
+        $__root__.createElement(ByDebugId('option1', usePlain: true), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('DebugIds', 'usePlain');
@@ -478,8 +473,8 @@ class $$DebugIds {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('DebugIds', 'useDash');
     }
-    final element = $__root__
-        .createElement(const ByDebugId('option2', useDash: true), [], []);
+    final element =
+        $__root__.createElement(ByDebugId('option2', useDash: true), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('DebugIds', 'useDash');
@@ -492,7 +487,7 @@ class $$DebugIds {
       __listener.startPageObjectMethod('DebugIds', 'useCamelCase');
     }
     final element = $__root__
-        .createElement(const ByDebugId('option3', useCamelCase: true), [], []);
+        .createElement(ByDebugId('option3', useCamelCase: true), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('DebugIds', 'useCamelCase');

--- a/test/src/annotations.g.dart
+++ b/test/src/annotations.g.dart
@@ -16,6 +16,12 @@ class $BaseObject extends BaseObject with $$BaseObject {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $BaseObject.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "BaseObject is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "BaseObject". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$BaseObject {
@@ -79,6 +85,12 @@ class $PseudoBaseObject extends PseudoBaseObject with $$PseudoBaseObject {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $PseudoBaseObject.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "PseudoBaseObject is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "PseudoBaseObject". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$PseudoBaseObject {
@@ -132,6 +144,9 @@ class $TableForCheckTag extends TableForCheckTag with $$TableForCheckTag {
       : $__root__ = currentContext {
     $__root__.addCheckers([new CheckTag('table')]);
   }
+  factory $TableForCheckTag.lookup(PageLoaderSource source) =>
+      new $TableForCheckTag.create(source.byTag('table'));
+  static String get tagName => 'table';
 }
 
 class $$TableForCheckTag {
@@ -184,6 +199,12 @@ class $BaseEnsureObject extends BaseEnsureObject with $$BaseEnsureObject {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $BaseEnsureObject.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "BaseEnsureObject is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "BaseEnsureObject". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$BaseEnsureObject {
@@ -223,6 +244,9 @@ class $TableForEnsureTag extends TableForEnsureTag with $$TableForEnsureTag {
             currentContext.createElement(const EnsureTag('table'), [], []) {
     $__root__.addCheckers([new EnsureTag('table')]);
   }
+  factory $TableForEnsureTag.lookup(PageLoaderSource source) =>
+      new $TableForEnsureTag.create(source.byTag('table'));
+  static String get tagName => 'table';
 }
 
 class $$TableForEnsureTag {
@@ -262,6 +286,9 @@ class $CheckTagFails extends CheckTagFails with $$CheckTagFails {
       : $__root__ = currentContext {
     $__root__.addCheckers([new CheckTag('inconceivable')]);
   }
+  factory $CheckTagFails.lookup(PageLoaderSource source) =>
+      new $CheckTagFails.create(source.byTag('inconceivable'));
+  static String get tagName => 'inconceivable';
 }
 
 class $$CheckTagFails {
@@ -289,6 +316,9 @@ class $EnsureTagFails extends EnsureTagFails with $$EnsureTagFails {
             .createElement(const EnsureTag('inconceivable'), [], []) {
     $__root__.addCheckers([new EnsureTag('inconceivable')]);
   }
+  factory $EnsureTagFails.lookup(PageLoaderSource source) =>
+      new $EnsureTagFails.create(source.byTag('inconceivable'));
+  static String get tagName => 'inconceivable';
 }
 
 class $$EnsureTagFails {
@@ -316,6 +346,12 @@ class $PageForWithAttributeTest extends PageForWithAttributeTest
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $PageForWithAttributeTest.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "PageForWithAttributeTest is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "PageForWithAttributeTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$PageForWithAttributeTest {
@@ -344,6 +380,12 @@ class $PageForWithClassTest extends PageForWithClassTest
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $PageForWithClassTest.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "PageForWithClassTest is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "PageForWithClassTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$PageForWithClassTest {
@@ -371,6 +413,12 @@ class $DebugIds extends DebugIds with $$DebugIds {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $DebugIds.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "DebugIds is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "DebugIds". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$DebugIds {

--- a/test/src/attributes.dart
+++ b/test/src/attributes.dart
@@ -21,7 +21,7 @@ typedef PageLoaderElement GetNewContext();
 void runTests(GetNewContext contextGenerator) {
   group('attributes ', () {
     test('style', () async {
-      final page = new PageForAttributesTests.create(contextGenerator());
+      final page = PageForAttributesTests.create(contextGenerator());
       // According to the spec, red below should be returned as an
       // RGBA value.
       expect(page.divWithStyle.attributes['style'],
@@ -33,25 +33,25 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('checked', () async {
-      final page = new PageForAttributesTests.create(contextGenerator());
+      final page = PageForAttributesTests.create(contextGenerator());
       expect(page.checkbox.attributes['checked'], isNull);
       await page.checkbox.click();
       expect(page.checkbox.attributes['checked'], isNull);
     });
 
     test('disabled', () async {
-      final page = new PageForAttributesTests.create(contextGenerator());
+      final page = PageForAttributesTests.create(contextGenerator());
       expect(page.readOnly.attributes['disabled'], '');
       expect(page.text.attributes['disabled'], isNull);
     });
 
     test('not a property', () async {
-      final page = new PageForAttributesTests.create(contextGenerator());
+      final page = PageForAttributesTests.create(contextGenerator());
       expect(page.table.attributes['non-standard'], 'a non standard attr');
     });
 
     test('option values', () async {
-      final page = new PageForAttributesTests.create(contextGenerator());
+      final page = PageForAttributesTests.create(contextGenerator());
       expect(page.option1.attributes['value'], 'value 1');
       expect(page.option1.attributes['VaLuE'], 'value 1');
       expect(page.option2.attributes['value'], 'value 2');
@@ -59,13 +59,13 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('option selected', () async {
-      final page = new PageForAttributesTests.create(contextGenerator());
+      final page = PageForAttributesTests.create(contextGenerator());
       await page.option2.click();
       expect(page.select1.attributes['value'], isNull);
     });
 
     test('selected on checkbox', () async {
-      final page = new PageForAttributesTests.create(contextGenerator());
+      final page = PageForAttributesTests.create(contextGenerator());
       expect(page.checkbox.attributes['selected'], isNull);
       expect(page.checkbox.attributes['SeLeCtEd'], isNull);
       await page.checkbox.click();
@@ -74,7 +74,7 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('selected on radio', () async {
-      final page = new PageForAttributesTests.create(contextGenerator());
+      final page = PageForAttributesTests.create(contextGenerator());
       expect(page.radio.attributes['selected'], isNull);
       expect(page.radio.attributes['SeLeCtEd'], isNull);
       await page.radio.click();
@@ -83,23 +83,23 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('href on a', () async {
-      final page = new PageForAttributesTests.create(contextGenerator());
+      final page = PageForAttributesTests.create(contextGenerator());
       expect(page.anchor.attributes['href'], endsWith('test.html'));
     });
 
     test('src on img', () async {
-      final page = new PageForAttributesTests.create(contextGenerator());
+      final page = PageForAttributesTests.create(contextGenerator());
       expect(page.img.attributes['src'], endsWith('test.png'));
     });
 
     test('class/className', () async {
-      final page = new PageForAttributesTests.create(contextGenerator());
+      final page = PageForAttributesTests.create(contextGenerator());
       expect(page.table.attributes['class'], 'class1 class2 class3');
       expect(page.table.attributes['className'], isNull);
     });
 
     test('readonly/readOnly', () async {
-      final page = new PageForAttributesTests.create(contextGenerator());
+      final page = PageForAttributesTests.create(contextGenerator());
       expect(page.readOnly.attributes['readonly'], '');
       expect(page.readOnly.attributes['readOnly'], '');
       expect(page.text.attributes['readonly'], isNull);
@@ -107,7 +107,7 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('value on text', () async {
-      final page = new PageForAttributesTests.create(contextGenerator());
+      final page = PageForAttributesTests.create(contextGenerator());
       expect(page.text.attributes['value'], isNull);
       await page.text.type('some text');
       expect(page.text.attributes['value'], isNull);

--- a/test/src/attributes.g.dart
+++ b/test/src/attributes.g.dart
@@ -27,14 +27,14 @@ class $PageForAttributesTests extends PageForAttributesTests
 
 class $$PageForAttributesTests {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get divWithStyle {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod(
           'PageForAttributesTests', 'divWithStyle');
     }
-    final element = $__root__.createElement(const ById('div'), [], []);
+    final element = $__root__.createElement(ById('div'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForAttributesTests', 'divWithStyle');
@@ -47,7 +47,7 @@ class $$PageForAttributesTests {
       __listener.startPageObjectMethod('PageForAttributesTests', 'checkbox');
     }
     final element =
-        $__root__.createElement(const ByCss('input[type=checkbox]'), [], []);
+        $__root__.createElement(ByCss('input[type=checkbox]'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForAttributesTests', 'checkbox');
@@ -59,7 +59,7 @@ class $$PageForAttributesTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForAttributesTests', 'table');
     }
-    final element = $__root__.createElement(const ById('table1'), [], []);
+    final element = $__root__.createElement(ById('table1'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForAttributesTests', 'table');
@@ -71,7 +71,7 @@ class $$PageForAttributesTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForAttributesTests', 'select1');
     }
-    final element = $__root__.createElement(const ById('select1'), [], []);
+    final element = $__root__.createElement(ById('select1'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForAttributesTests', 'select1');
@@ -83,7 +83,7 @@ class $$PageForAttributesTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForAttributesTests', 'option1');
     }
-    final element = $__root__.createElement(const ById('option1'), [], []);
+    final element = $__root__.createElement(ById('option1'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForAttributesTests', 'option1');
@@ -95,7 +95,7 @@ class $$PageForAttributesTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForAttributesTests', 'option2');
     }
-    final element = $__root__.createElement(const ById('option2'), [], []);
+    final element = $__root__.createElement(ById('option2'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForAttributesTests', 'option2');
@@ -108,7 +108,7 @@ class $$PageForAttributesTests {
       __listener.startPageObjectMethod('PageForAttributesTests', 'radio');
     }
     final element =
-        $__root__.createElement(const ByCss('input[value=radio1]'), [], []);
+        $__root__.createElement(ByCss('input[value=radio1]'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForAttributesTests', 'radio');
@@ -120,7 +120,7 @@ class $$PageForAttributesTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForAttributesTests', 'anchor');
     }
-    final element = $__root__.createElement(const ById('anchor'), [], []);
+    final element = $__root__.createElement(ById('anchor'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForAttributesTests', 'anchor');
@@ -132,7 +132,7 @@ class $$PageForAttributesTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForAttributesTests', 'img');
     }
-    final element = $__root__.createElement(const ByTagName('img'), [], []);
+    final element = $__root__.createElement(ByTagName('img'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForAttributesTests', 'img');
@@ -144,7 +144,7 @@ class $$PageForAttributesTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForAttributesTests', 'readOnly');
     }
-    final element = $__root__.createElement(const ById('readonly'), [], []);
+    final element = $__root__.createElement(ById('readonly'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForAttributesTests', 'readOnly');
@@ -156,7 +156,7 @@ class $$PageForAttributesTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForAttributesTests', 'text');
     }
-    final element = $__root__.createElement(const ById('text'), [], []);
+    final element = $__root__.createElement(ById('text'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForAttributesTests', 'text');

--- a/test/src/attributes.g.dart
+++ b/test/src/attributes.g.dart
@@ -17,6 +17,12 @@ class $PageForAttributesTests extends PageForAttributesTests
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $PageForAttributesTests.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "PageForAttributesTests is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "PageForAttributesTests". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$PageForAttributesTests {

--- a/test/src/basic.dart
+++ b/test/src/basic.dart
@@ -26,33 +26,33 @@ typedef PageLoaderElement GetNewContext();
 void runTests(GetNewContext contextGenerator) {
   group('basic', () {
     test('load', () async {
-      final basic = new Basic.create(contextGenerator());
+      final basic = Basic.create(contextGenerator());
       final innerNested = basic.outerNested.innerNested;
       expect(innerNested.visibleText, 'inner nested');
     });
 
     test('simple page', () async {
-      final page = new PageForSimpleTest.create(contextGenerator());
+      final page = PageForSimpleTest.create(contextGenerator());
       await verifyTable(page.table);
     });
 
     test('class annotations', () async {
-      final table = new Table.create(contextGenerator());
+      final table = Table.create(contextGenerator());
       await verifyTable(table);
     });
 
     test('class annotation on nested field', () async {
-      final page = new PageForClassAnnotationTest.create(contextGenerator());
+      final page = PageForClassAnnotationTest.create(contextGenerator());
       await verifyTable(page.table);
     });
 
     test('private fields', () async {
-      final page = new PageForPrivateFieldsTest.create(contextGenerator());
+      final page = PageForPrivateFieldsTest.create(contextGenerator());
       await verifyTable(page.table);
     });
 
     test('has focus', () async {
-      final page = new PageForFocusTest.create(contextGenerator());
+      final page = PageForFocusTest.create(contextGenerator());
       expect(page.textfield.isFocused, false);
 
       await page.textfield.focus();
@@ -63,7 +63,7 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('classes', () async {
-      final page = new PageForSimpleTest.create(contextGenerator());
+      final page = PageForSimpleTest.create(contextGenerator());
 
       expect(page.table.table.classes,
           orderedEquals(['class1', 'class2', 'class3']));
@@ -72,14 +72,14 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('style', () async {
-      final page = new PageForSimpleTest.create(contextGenerator());
+      final page = PageForSimpleTest.create(contextGenerator());
 
       expect(page.table.table.style['color'], 'rgb(128, 0, 128)');
       expect(page.table.table.style['backgroundColor'], '');
     });
 
     test('computedStyle', () async {
-      final page = new PageForSimpleTest.create(contextGenerator());
+      final page = PageForSimpleTest.create(contextGenerator());
 
       expect(page.table.table.computedStyle['color'], 'rgb(128, 0, 128)');
       expect(
@@ -87,19 +87,19 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('exists', () async {
-      final page = new PageForExistsTest.create(contextGenerator());
+      final page = PageForExistsTest.create(contextGenerator());
       expect(page.doesExist, exists);
       expect(page.doesntExist, notExists);
     });
 
     test('visibility', () async {
-      final page = new PageForVisibilityTest.create(contextGenerator());
+      final page = PageForVisibilityTest.create(contextGenerator());
       expect(page.visibleButton, isNot(hasClass('invisible')));
       expect(page.invisibleDiv, hasClass('invisible'));
     });
 
     test('exist throws on multiple elements with exists', () async {
-      final page = new PageForExistsTest.create(contextGenerator());
+      final page = PageForExistsTest.create(contextGenerator());
       try {
         page.tooManyExist.exists;
         fail('Expected to throw on exists with multiple element');
@@ -112,7 +112,7 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('actions throw on non-existant elements', () async {
-      final page = new PageForExistsTest.create(contextGenerator());
+      final page = PageForExistsTest.create(contextGenerator());
       try {
         await page.doesntExist.click();
         fail('Expected to throw on clicking non-existant element');
@@ -123,28 +123,28 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('nbsp in text', () async {
-      final page = new PageForNbspTest.create(contextGenerator());
+      final page = PageForNbspTest.create(contextGenerator());
       expect(page.span.visibleText, '   ');
       expect(page.span.innerText, '');
     });
 
     test('list', () async {
-      final page = new list_shared.PageForSimpleTest.create(contextGenerator());
+      final page = list_shared.PageForSimpleTest.create(contextGenerator());
       await list_shared.verifyTable(page.table);
     });
 
     test('debugId', () async {
-      final page = new DebugId.create(contextGenerator());
+      final page = DebugId.create(contextGenerator());
       expect(page.debug.exists, isTrue);
     });
 
     test('displayed works', () async {
-      final page = new DebugId.create(contextGenerator());
+      final page = DebugId.create(contextGenerator());
       expect(page.debug.displayed, isTrue);
     });
 
     test('not displayed works', () async {
-      final page = new Display.create(contextGenerator());
+      final page = Display.create(contextGenerator());
       expect(page.notDisplayed.displayed, isFalse);
     });
 

--- a/test/src/basic.g.dart
+++ b/test/src/basic.g.dart
@@ -26,14 +26,13 @@ class $PageForExistsTest extends PageForExistsTest with $$PageForExistsTest {
 
 class $$PageForExistsTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get doesntExist {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForExistsTest', 'doesntExist');
     }
-    final element =
-        $__root__.createElement(const ByTagName('non-existant'), [], []);
+    final element = $__root__.createElement(ByTagName('non-existant'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForExistsTest', 'doesntExist');
@@ -45,7 +44,7 @@ class $$PageForExistsTest {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForExistsTest', 'doesExist');
     }
-    final element = $__root__.createElement(const ById('button-1'), [], []);
+    final element = $__root__.createElement(ById('button-1'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForExistsTest', 'doesExist');
@@ -57,7 +56,7 @@ class $$PageForExistsTest {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForExistsTest', 'tooManyExist');
     }
-    final element = $__root__.createElement(const ByTagName('td'), [], []);
+    final element = $__root__.createElement(ByTagName('td'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForExistsTest', 'tooManyExist');
@@ -84,14 +83,13 @@ class $PageForVisibilityTest extends PageForVisibilityTest
 
 class $$PageForVisibilityTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get invisibleDiv {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForVisibilityTest', 'invisibleDiv');
     }
-    final element =
-        $__root__.createElement(const ById('invisible-div'), [], []);
+    final element = $__root__.createElement(ById('invisible-div'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForVisibilityTest', 'invisibleDiv');
@@ -104,7 +102,7 @@ class $$PageForVisibilityTest {
       __listener.startPageObjectMethod(
           'PageForVisibilityTest', 'visibleButton');
     }
-    final element = $__root__.createElement(const ById('button-1'), [], []);
+    final element = $__root__.createElement(ById('button-1'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForVisibilityTest', 'visibleButton');
@@ -131,14 +129,14 @@ class $PageForClassAnnotationTest extends PageForClassAnnotationTest
 
 class $$PageForClassAnnotationTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   Table get table {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForClassAnnotationTest', 'table');
     }
     final element = $__root__;
-    final returnMe = new Table.create(element);
+    final returnMe = Table.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForClassAnnotationTest', 'table');
     }
@@ -174,15 +172,15 @@ class $PageForPrivateFieldsTest extends PageForPrivateFieldsTest
 
 class $$PageForPrivateFieldsTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   Table get _privateTable {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod(
           'PageForPrivateFieldsTest', '_privateTable');
     }
-    final element = $__root__.createElement(const ByTagName('table'), [], []);
-    final returnMe = new Table.create(element);
+    final element = $__root__.createElement(ByTagName('table'), [], []);
+    final returnMe = Table.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod(
           'PageForPrivateFieldsTest', '_privateTable');
@@ -208,13 +206,13 @@ class $PageForFocusTest extends PageForFocusTest with $$PageForFocusTest {
 
 class $$PageForFocusTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get textfield {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForFocusTest', 'textfield');
     }
-    final element = $__root__.createElement(const ById('text'), [], []);
+    final element = $__root__.createElement(ById('text'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForFocusTest', 'textfield');
@@ -240,13 +238,13 @@ class $PageForNbspTest extends PageForNbspTest with $$PageForNbspTest {
 
 class $$PageForNbspTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get span {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForNbspTest', 'span');
     }
-    final element = $__root__.createElement(const ById('nbsp'), [], []);
+    final element = $__root__.createElement(ById('nbsp'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForNbspTest', 'span');
@@ -271,15 +269,14 @@ class $Basic extends Basic with $$Basic {
 
 class $$Basic {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   OuterNested get outerNested {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Basic', 'outerNested');
     }
-    final element =
-        $__root__.createElement(const ByClass('outer-nested'), [], []);
-    final returnMe = new OuterNested.create(element);
+    final element = $__root__.createElement(ByClass('outer-nested'), [], []);
+    final returnMe = OuterNested.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Basic', 'outerNested');
     }
@@ -304,14 +301,13 @@ class $OuterNested extends OuterNested with $$OuterNested {
 
 class $$OuterNested {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get innerNested {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('OuterNested', 'innerNested');
     }
-    final element =
-        $__root__.createElement(const ByClass('inner-nested'), [], []);
+    final element = $__root__.createElement(ByClass('inner-nested'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('OuterNested', 'innerNested');
@@ -337,13 +333,13 @@ class $DebugId extends DebugId with $$DebugId {
 
 class $$DebugId {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get debug {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('DebugId', 'debug');
     }
-    final element = $__root__.createElement(const ByDebugId('debugId'), [], []);
+    final element = $__root__.createElement(ByDebugId('debugId'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('DebugId', 'debug');
@@ -369,13 +365,13 @@ class $Display extends Display with $$Display {
 
 class $$Display {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get notDisplayed {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Display', 'notDisplayed');
     }
-    final element = $__root__.createElement(const ById('div'), [], []);
+    final element = $__root__.createElement(ById('div'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Display', 'notDisplayed');

--- a/test/src/basic.g.dart
+++ b/test/src/basic.g.dart
@@ -16,6 +16,12 @@ class $PageForExistsTest extends PageForExistsTest with $$PageForExistsTest {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $PageForExistsTest.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "PageForExistsTest is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "PageForExistsTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$PageForExistsTest {
@@ -68,6 +74,12 @@ class $PageForVisibilityTest extends PageForVisibilityTest
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $PageForVisibilityTest.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "PageForVisibilityTest is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "PageForVisibilityTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$PageForVisibilityTest {
@@ -109,6 +121,12 @@ class $PageForClassAnnotationTest extends PageForClassAnnotationTest
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $PageForClassAnnotationTest.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "PageForClassAnnotationTest is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "PageForClassAnnotationTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$PageForClassAnnotationTest {
@@ -136,6 +154,12 @@ class $PageForPrivateFieldsTest extends PageForPrivateFieldsTest
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $PageForPrivateFieldsTest.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "PageForPrivateFieldsTest is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "PageForPrivateFieldsTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
   Table get table {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForPrivateFieldsTest', 'table');
@@ -174,6 +198,12 @@ class $PageForFocusTest extends PageForFocusTest with $$PageForFocusTest {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $PageForFocusTest.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "PageForFocusTest is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "PageForFocusTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$PageForFocusTest {
@@ -200,6 +230,12 @@ class $PageForNbspTest extends PageForNbspTest with $$PageForNbspTest {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $PageForNbspTest.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "PageForNbspTest is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "PageForNbspTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$PageForNbspTest {
@@ -225,6 +261,12 @@ class $Basic extends Basic with $$Basic {
   $Basic.create(PageLoaderElement currentContext) : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Basic.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Basic is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Basic". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$Basic {
@@ -252,6 +294,12 @@ class $OuterNested extends OuterNested with $$OuterNested {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $OuterNested.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "OuterNested is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "OuterNested". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$OuterNested {
@@ -279,6 +327,12 @@ class $DebugId extends DebugId with $$DebugId {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $DebugId.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "DebugId is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "DebugId". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$DebugId {
@@ -305,6 +359,12 @@ class $Display extends Display with $$Display {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Display.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Display is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Display". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$Display {

--- a/test/src/cache_invalidation.dart
+++ b/test/src/cache_invalidation.dart
@@ -24,8 +24,7 @@ typedef void DoRefresh();
 void runTests(GetNewContext contextGenerator, DoRefresh refresh) {
   group('cache invalidation ', () {
     test('handled correctly for single', () async {
-      final cacheInvalidation =
-          new CacheInvalidation.create(contextGenerator());
+      final cacheInvalidation = CacheInvalidation.create(contextGenerator());
       final button1 = cacheInvalidation.button1;
       await button1.click();
       refresh();
@@ -33,8 +32,7 @@ void runTests(GetNewContext contextGenerator, DoRefresh refresh) {
     });
 
     test('stale elements handled correctly for nested', () async {
-      final cacheInvalidation =
-          new CacheInvalidation.create(contextGenerator());
+      final cacheInvalidation = CacheInvalidation.create(contextGenerator());
       final select1 = cacheInvalidation.select1;
       expect(select1.option1.innerText, 'option 1');
       expect(select1.option2.innerText, 'option 2');

--- a/test/src/cache_invalidation.g.dart
+++ b/test/src/cache_invalidation.g.dart
@@ -16,6 +16,12 @@ class $CacheInvalidation extends CacheInvalidation with $$CacheInvalidation {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $CacheInvalidation.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "CacheInvalidation is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "CacheInvalidation". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$CacheInvalidation {
@@ -54,6 +60,12 @@ class $_Nested extends _Nested with $$_Nested {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $_Nested.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "_Nested is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "_Nested". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$_Nested {

--- a/test/src/cache_invalidation.g.dart
+++ b/test/src/cache_invalidation.g.dart
@@ -26,13 +26,13 @@ class $CacheInvalidation extends CacheInvalidation with $$CacheInvalidation {
 
 class $$CacheInvalidation {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get button1 {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('CacheInvalidation', 'button1');
     }
-    final element = $__root__.createElement(const ById('button-1'), [], []);
+    final element = $__root__.createElement(ById('button-1'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('CacheInvalidation', 'button1');
@@ -44,8 +44,8 @@ class $$CacheInvalidation {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('CacheInvalidation', 'select1');
     }
-    final element = $__root__.createElement(const ById('select1'), [], []);
-    final returnMe = new _Nested.create(element);
+    final element = $__root__.createElement(ById('select1'), [], []);
+    final returnMe = _Nested.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('CacheInvalidation', 'select1');
     }
@@ -70,13 +70,13 @@ class $_Nested extends _Nested with $$_Nested {
 
 class $$_Nested {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get option1 {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('_Nested', 'option1');
     }
-    final element = $__root__.createElement(const ById('option1'), [], []);
+    final element = $__root__.createElement(ById('option1'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('_Nested', 'option1');
@@ -88,7 +88,7 @@ class $$_Nested {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('_Nested', 'option2');
     }
-    final element = $__root__.createElement(const ById('option2'), [], []);
+    final element = $__root__.createElement(ById('option2'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('_Nested', 'option2');

--- a/test/src/constructors.dart
+++ b/test/src/constructors.dart
@@ -1,0 +1,125 @@
+// Copyright 2018 Google Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:pageloader/pageloader.dart';
+import 'package:test/test.dart';
+
+part 'constructors.g.dart';
+
+typedef PageLoaderElement GetNewContext();
+
+void runTests(GetNewContext contextGenerator) {
+  group('lookup constructor', () {
+    BasePO base;
+    BCustomTagPO bTag;
+
+    setUp(() {
+      base = new BasePO.create(contextGenerator());
+      bTag = base.bTagPO;
+    });
+
+    test('works with PLE', () async {
+      final cTag = bTag.cTagFromPLE;
+      expect(cTag.innerText, equals('C tag inner text'));
+    });
+
+    test('works with utils', () async {
+      final cTag = bTag.cTagFromUtils;
+      expect(cTag.innerText, equals('C tag inner text'));
+    });
+
+    test('on PO without CheckTag should fail', () async {
+      try {
+        bTag.noLookupPO;
+        fail('Expected to throw error on lookup usage without CheckTag');
+      } catch (e) {
+        expect(
+            e.toString(),
+            contains("'lookup' constructor for class NoLookupPO"
+                " is not generated and can only be used on Page Object classes"
+                " that have @CheckTag annotation."));
+      }
+    });
+  });
+
+  group('generated fields', () {
+    test('tagName exists', () {
+      expect($BCustomTagPO.tagName, equals('b-custom-tag'));
+    });
+
+    test('tagName throws error', () {
+      try {
+        $NoLookupPO.tagName;
+        fail('Expected to throw error on tagName usage without CheckTag');
+      } catch (e) {
+        expect(
+            e.toString(),
+            contains('\"tagName\" '
+                'is not defined by Page Object \"NoLookupPO\". Requires @CheckTag '
+                'annotation in order for \"tagName\" to be generated.'));
+      }
+    });
+  });
+}
+
+@PageObject()
+abstract class BasePO {
+  BasePO();
+  factory BasePO.create(PageLoaderElement context) = $BasePO.create;
+
+  @ByTagName(BCustomTagPO.tagName)
+  BCustomTagPO get bTagPO;
+}
+
+@PageObject()
+@CheckTag(BCustomTagPO.tagName)
+abstract class BCustomTagPO {
+  BCustomTagPO();
+  factory BCustomTagPO.create(PageLoaderElement context) = $BCustomTagPO.create;
+
+  static const tagName = 'b-custom-tag';
+
+  @root
+  PageLoaderElement get _root;
+
+  PageLoaderElement get rootElement => _root;
+
+  PageUtils get _utils => _root.utils;
+
+  CCustomTagPO get cTagFromPLE => new CCustomTagPO.lookup(_root);
+  CCustomTagPO get cTagFromUtils => new CCustomTagPO.lookup(_utils);
+
+  NoLookupPO get noLookupPO => new NoLookupPO.lookup(_root);
+}
+
+@PageObject()
+@CheckTag(CCustomTagPO.tagName)
+abstract class CCustomTagPO {
+  CCustomTagPO();
+  factory CCustomTagPO.create(PageLoaderElement context) = $CCustomTagPO.create;
+  factory CCustomTagPO.lookup(PageLoaderSource source) = $CCustomTagPO.lookup;
+
+  static const tagName = 'c-custom-tag';
+
+  @root
+  PageLoaderElement get _root;
+
+  String get innerText => _root.innerText;
+}
+
+@PageObject()
+abstract class NoLookupPO {
+  NoLookupPO();
+  factory NoLookupPO.create(PageLoaderElement context) = $NoLookupPO.create;
+  factory NoLookupPO.lookup(PageLoaderSource source) = $NoLookupPO.lookup;
+}

--- a/test/src/constructors.dart
+++ b/test/src/constructors.dart
@@ -24,7 +24,7 @@ void runTests(GetNewContext contextGenerator) {
     BCustomTagPO bTag;
 
     setUp(() {
-      base = new BasePO.create(contextGenerator());
+      base = BasePO.create(contextGenerator());
       bTag = base.bTagPO;
     });
 
@@ -96,10 +96,10 @@ abstract class BCustomTagPO {
 
   PageUtils get _utils => _root.utils;
 
-  CCustomTagPO get cTagFromPLE => new CCustomTagPO.lookup(_root);
-  CCustomTagPO get cTagFromUtils => new CCustomTagPO.lookup(_utils);
+  CCustomTagPO get cTagFromPLE => CCustomTagPO.lookup(_root);
+  CCustomTagPO get cTagFromUtils => CCustomTagPO.lookup(_utils);
 
-  NoLookupPO get noLookupPO => new NoLookupPO.lookup(_root);
+  NoLookupPO get noLookupPO => NoLookupPO.lookup(_root);
 }
 
 @PageObject()

--- a/test/src/constructors.g.dart
+++ b/test/src/constructors.g.dart
@@ -26,15 +26,15 @@ class $BasePO extends BasePO with $$BasePO {
 
 class $$BasePO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   BCustomTagPO get bTagPO {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('BasePO', 'bTagPO');
     }
     final element =
-        $__root__.createElement(const ByTagName(BCustomTagPO.tagName), [], []);
-    final returnMe = new BCustomTagPO.create(element);
+        $__root__.createElement(ByTagName(BCustomTagPO.tagName), [], []);
+    final returnMe = BCustomTagPO.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('BasePO', 'bTagPO');
     }
@@ -47,10 +47,10 @@ class $BCustomTagPO extends BCustomTagPO with $$BCustomTagPO {
   PageLoaderElement $__root__;
   $BCustomTagPO.create(PageLoaderElement currentContext)
       : $__root__ = currentContext {
-    $__root__.addCheckers([new CheckTag(BCustomTagPO.tagName)]);
+    $__root__.addCheckers([CheckTag(BCustomTagPO.tagName)]);
   }
   factory $BCustomTagPO.lookup(PageLoaderSource source) =>
-      new $BCustomTagPO.create(source.byTag(BCustomTagPO.tagName));
+      $BCustomTagPO.create(source.byTag(BCustomTagPO.tagName));
   static String get tagName => BCustomTagPO.tagName;
   PageLoaderElement get rootElement {
     for (final __listener in $__root__.listeners) {
@@ -110,7 +110,7 @@ class $BCustomTagPO extends BCustomTagPO with $$BCustomTagPO {
 
 class $$BCustomTagPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get _root {
     for (final __listener in $__root__.listeners) {
@@ -130,10 +130,10 @@ class $CCustomTagPO extends CCustomTagPO with $$CCustomTagPO {
   PageLoaderElement $__root__;
   $CCustomTagPO.create(PageLoaderElement currentContext)
       : $__root__ = currentContext {
-    $__root__.addCheckers([new CheckTag(CCustomTagPO.tagName)]);
+    $__root__.addCheckers([CheckTag(CCustomTagPO.tagName)]);
   }
   factory $CCustomTagPO.lookup(PageLoaderSource source) =>
-      new $CCustomTagPO.create(source.byTag(CCustomTagPO.tagName));
+      $CCustomTagPO.create(source.byTag(CCustomTagPO.tagName));
   static String get tagName => CCustomTagPO.tagName;
   String get innerText {
     for (final __listener in $__root__.listeners) {
@@ -149,7 +149,7 @@ class $CCustomTagPO extends CCustomTagPO with $$CCustomTagPO {
 
 class $$CCustomTagPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get _root {
     for (final __listener in $__root__.listeners) {
@@ -181,6 +181,6 @@ class $NoLookupPO extends NoLookupPO with $$NoLookupPO {
 
 class $$NoLookupPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }

--- a/test/src/constructors.g.dart
+++ b/test/src/constructors.g.dart
@@ -1,0 +1,186 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: unused_field, non_constant_identifier_names
+// ignore_for_file: overridden_fields, annotate_overrides
+
+part of 'constructors.dart';
+
+// **************************************************************************
+// PageObjectGenerator
+// **************************************************************************
+
+// ignore_for_file: private_collision_in_mixin_application
+class $BasePO extends BasePO with $$BasePO {
+  PageLoaderElement $__root__;
+  $BasePO.create(PageLoaderElement currentContext)
+      : $__root__ = currentContext {
+    $__root__.addCheckers([]);
+  }
+  factory $BasePO.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "BasePO is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "BasePO". Requires @CheckTag annotation in order for "tagName" to be generated.';
+}
+
+class $$BasePO {
+  PageLoaderElement $__root__;
+  PageLoaderMouse __mouse__;
+  PageLoaderElement get $root => $__root__;
+  BCustomTagPO get bTagPO {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('BasePO', 'bTagPO');
+    }
+    final element =
+        $__root__.createElement(const ByTagName(BCustomTagPO.tagName), [], []);
+    final returnMe = new BCustomTagPO.create(element);
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('BasePO', 'bTagPO');
+    }
+    return returnMe;
+  }
+}
+
+// ignore_for_file: private_collision_in_mixin_application
+class $BCustomTagPO extends BCustomTagPO with $$BCustomTagPO {
+  PageLoaderElement $__root__;
+  $BCustomTagPO.create(PageLoaderElement currentContext)
+      : $__root__ = currentContext {
+    $__root__.addCheckers([new CheckTag(BCustomTagPO.tagName)]);
+  }
+  factory $BCustomTagPO.lookup(PageLoaderSource source) =>
+      new $BCustomTagPO.create(source.byTag(BCustomTagPO.tagName));
+  static String get tagName => BCustomTagPO.tagName;
+  PageLoaderElement get rootElement {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('BCustomTagPO', 'rootElement');
+    }
+    final returnMe = super.rootElement;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('BCustomTagPO', 'rootElement');
+    }
+    return returnMe;
+  }
+
+  PageUtils get _utils {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('BCustomTagPO', '_utils');
+    }
+    final returnMe = super._utils;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('BCustomTagPO', '_utils');
+    }
+    return returnMe;
+  }
+
+  CCustomTagPO get cTagFromPLE {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('BCustomTagPO', 'cTagFromPLE');
+    }
+    final returnMe = super.cTagFromPLE;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('BCustomTagPO', 'cTagFromPLE');
+    }
+    return returnMe;
+  }
+
+  CCustomTagPO get cTagFromUtils {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('BCustomTagPO', 'cTagFromUtils');
+    }
+    final returnMe = super.cTagFromUtils;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('BCustomTagPO', 'cTagFromUtils');
+    }
+    return returnMe;
+  }
+
+  NoLookupPO get noLookupPO {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('BCustomTagPO', 'noLookupPO');
+    }
+    final returnMe = super.noLookupPO;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('BCustomTagPO', 'noLookupPO');
+    }
+    return returnMe;
+  }
+}
+
+class $$BCustomTagPO {
+  PageLoaderElement $__root__;
+  PageLoaderMouse __mouse__;
+  PageLoaderElement get $root => $__root__;
+  PageLoaderElement get _root {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('BCustomTagPO', '_root');
+    }
+    final element = $__root__;
+    final returnMe = element;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('BCustomTagPO', '_root');
+    }
+    return returnMe;
+  }
+}
+
+// ignore_for_file: private_collision_in_mixin_application
+class $CCustomTagPO extends CCustomTagPO with $$CCustomTagPO {
+  PageLoaderElement $__root__;
+  $CCustomTagPO.create(PageLoaderElement currentContext)
+      : $__root__ = currentContext {
+    $__root__.addCheckers([new CheckTag(CCustomTagPO.tagName)]);
+  }
+  factory $CCustomTagPO.lookup(PageLoaderSource source) =>
+      new $CCustomTagPO.create(source.byTag(CCustomTagPO.tagName));
+  static String get tagName => CCustomTagPO.tagName;
+  String get innerText {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('CCustomTagPO', 'innerText');
+    }
+    final returnMe = super.innerText;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('CCustomTagPO', 'innerText');
+    }
+    return returnMe;
+  }
+}
+
+class $$CCustomTagPO {
+  PageLoaderElement $__root__;
+  PageLoaderMouse __mouse__;
+  PageLoaderElement get $root => $__root__;
+  PageLoaderElement get _root {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('CCustomTagPO', '_root');
+    }
+    final element = $__root__;
+    final returnMe = element;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('CCustomTagPO', '_root');
+    }
+    return returnMe;
+  }
+}
+
+// ignore_for_file: private_collision_in_mixin_application
+class $NoLookupPO extends NoLookupPO with $$NoLookupPO {
+  PageLoaderElement $__root__;
+  $NoLookupPO.create(PageLoaderElement currentContext)
+      : $__root__ = currentContext {
+    $__root__.addCheckers([]);
+  }
+  factory $NoLookupPO.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "NoLookupPO is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "NoLookupPO". Requires @CheckTag annotation in order for "tagName" to be generated.';
+}
+
+class $$NoLookupPO {
+  PageLoaderElement $__root__;
+  PageLoaderMouse __mouse__;
+  PageLoaderElement get $root => $__root__;
+}

--- a/test/src/debug.dart
+++ b/test/src/debug.dart
@@ -32,9 +32,9 @@ void runTests(GetNewContext contextGenerator) {
     test('trace listener', () async {
       var printedLines = <String>[];
       root.addListeners(
-          [new TraceListener(printLine: (String s) => printedLines.add(s))]);
+          [TraceListener(printLine: (String s) => printedLines.add(s))]);
 
-      final page = new PageForSimpleTest.create(root);
+      final page = PageForSimpleTest.create(root);
       expect(page.table.table.exists, true); // Do something.
       printedLines =
           printedLines.map((s) => s.trim()).toList(); // Drop the whitespace.
@@ -45,10 +45,10 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('profiler listener', () async {
-      final timerFactory = new CollectingTimerFactory();
-      root.addListeners([new ProfilerListener(timerFactory)]);
+      final timerFactory = CollectingTimerFactory();
+      root.addListeners([ProfilerListener(timerFactory)]);
 
-      final page = new PageForSimpleTest.create(root);
+      final page = PageForSimpleTest.create(root);
 
       await page.table.table.click();
       await page.table.doSlowAction(); // Do something.

--- a/test/src/generics.dart
+++ b/test/src/generics.dart
@@ -21,18 +21,18 @@ typedef PageLoaderElement GetNewContext();
 void runTests(GetNewContext contextGenerator) {
   group('generics', () {
     test('works for functions', () async {
-      final generics = new Generics<int>.create(contextGenerator());
+      final generics = Generics<int>.create(contextGenerator());
       expect(generics.typeDefParameter(42, (int x) => x.toString()), '42');
     });
 
     test('works for parameterized getters', () {
-      final rootPo = new RootPo<String>.create(contextGenerator());
+      final rootPo = RootPo<String>.create(contextGenerator());
       expect(rootPo.generics.typeDefParameter(' 42 ', (String x) => x.trim()),
           '42');
     });
 
     test('words for parameterized getter lists', () {
-      final rootPo = new RootPo<String>.create(contextGenerator());
+      final rootPo = RootPo<String>.create(contextGenerator());
       expect(rootPo.genericsList, hasLength(4));
       expect(
           rootPo.genericsList[0]

--- a/test/src/generics.g.dart
+++ b/test/src/generics.g.dart
@@ -16,6 +16,12 @@ class $Generics<T> extends Generics<T> with $$Generics<T> {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Generics.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Generics is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Generics". Requires @CheckTag annotation in order for "tagName" to be generated.';
   String typeDefParameter(T thing, MyGenericTypeDef<T> typeDef) {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Generics', 'typeDefParameter');
@@ -41,6 +47,12 @@ class $RootPo<T> extends RootPo<T> with $$RootPo<T> {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $RootPo.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "RootPo is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "RootPo". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$RootPo<T> {

--- a/test/src/generics.g.dart
+++ b/test/src/generics.g.dart
@@ -36,7 +36,7 @@ class $Generics<T> extends Generics<T> with $$Generics<T> {
 
 class $$Generics<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
 }
 
@@ -57,14 +57,14 @@ class $RootPo<T> extends RootPo<T> with $$RootPo<T> {
 
 class $$RootPo<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   Generics<T> get generics {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('RootPo', 'generics');
     }
-    final element = $__root__.createElement(const ById('button-1'), [], []);
-    final returnMe = new Generics<T>.create(element);
+    final element = $__root__.createElement(ById('button-1'), [], []);
+    final returnMe = Generics<T>.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('RootPo', 'generics');
     }
@@ -75,9 +75,9 @@ class $$RootPo<T> {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('RootPo', 'genericsList');
     }
-    final returnMe = new PageObjectList<Generics<T>>(
-        $__root__.createList(const ByTagName('td'), [], []),
-        (PageLoaderElement e) => new Generics<T>.create(e));
+    final returnMe = PageObjectList<Generics<T>>(
+        $__root__.createList(ByTagName('td'), [], []),
+        (PageLoaderElement e) => Generics<T>.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('RootPo', 'genericsList');
     }

--- a/test/src/list.dart
+++ b/test/src/list.dart
@@ -32,7 +32,13 @@ void runTests(GetNewContext contextGenerator) {
     test('synchronously', () async {
       final list = new Lists.create(contextGenerator());
       final rows = list.tableRowsSync;
+      final rowsAsPO = list.tableRowsSyncAsPO;
       expect(rows, hasLength(2));
+      expect(rowsAsPO, hasLength(2));
+      expect(rowsAsPO[0].exists, isTrue);
+      expect(rowsAsPO[1].exists, isTrue);
+      expect(rows[0].exists, isTrue);
+      expect(rows[1].exists, isTrue);
       expect(_removeWhiteSpace(rows[0].innerText), 'r1c1r1c2');
       expect(_removeWhiteSpace(rows[1].innerText), 'r2c1r2c2');
     });
@@ -49,4 +55,19 @@ abstract class Lists {
 
   @ByTagName('tr')
   List<PageLoaderElement> get tableRowsSync;
+
+  @ByTagName('tr')
+  List<RowPO> get tableRowsSyncAsPO;
+}
+
+@CheckTag('tr')
+@PageObject()
+abstract class RowPO {
+  RowPO();
+  factory RowPO.create(PageLoaderElement context) = $RowPO.create;
+
+  @root
+  PageLoaderElement get _root;
+
+  bool get exists => _root.exists;
 }

--- a/test/src/list.dart
+++ b/test/src/list.dart
@@ -25,12 +25,12 @@ String _removeWhiteSpace(String s) =>
 void runTests(GetNewContext contextGenerator) {
   group('list works', () {
     test('asynchronously', () async {
-      final list = new Lists.create(contextGenerator());
+      final list = Lists.create(contextGenerator());
       expect(await list.tableRows, hasLength(2));
     });
 
     test('synchronously', () async {
-      final list = new Lists.create(contextGenerator());
+      final list = Lists.create(contextGenerator());
       final rows = list.tableRowsSync;
       final rowsAsPO = list.tableRowsSyncAsPO;
       expect(rows, hasLength(2));

--- a/test/src/list.g.dart
+++ b/test/src/list.g.dart
@@ -15,6 +15,12 @@ class $Lists extends Lists with $$Lists {
   $Lists.create(PageLoaderElement currentContext) : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Lists.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Lists is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Lists". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$Lists {
@@ -43,6 +49,57 @@ class $$Lists {
         (PageLoaderElement e) => e);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Lists', 'tableRowsSync');
+    }
+    return returnMe;
+  }
+
+  PageObjectList<RowPO> get tableRowsSyncAsPO {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('Lists', 'tableRowsSyncAsPO');
+    }
+    final returnMe = new PageObjectList<RowPO>(
+        $__root__.createList(const ByTagName('tr'), [], []),
+        (PageLoaderElement e) => new RowPO.create(e));
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('Lists', 'tableRowsSyncAsPO');
+    }
+    return returnMe;
+  }
+}
+
+// ignore_for_file: private_collision_in_mixin_application
+class $RowPO extends RowPO with $$RowPO {
+  PageLoaderElement $__root__;
+  $RowPO.create(PageLoaderElement currentContext) : $__root__ = currentContext {
+    $__root__.addCheckers([new CheckTag('tr')]);
+  }
+  factory $RowPO.lookup(PageLoaderSource source) =>
+      new $RowPO.create(source.byTag('tr'));
+  static String get tagName => 'tr';
+  bool get exists {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('RowPO', 'exists');
+    }
+    final returnMe = super.exists;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('RowPO', 'exists');
+    }
+    return returnMe;
+  }
+}
+
+class $$RowPO {
+  PageLoaderElement $__root__;
+  PageLoaderMouse __mouse__;
+  PageLoaderElement get $root => $__root__;
+  PageLoaderElement get _root {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('RowPO', '_root');
+    }
+    final element = $__root__;
+    final returnMe = element;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('RowPO', '_root');
     }
     return returnMe;
   }

--- a/test/src/list.g.dart
+++ b/test/src/list.g.dart
@@ -25,14 +25,14 @@ class $Lists extends Lists with $$Lists {
 
 class $$Lists {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   Future<PageObjectList<PageLoaderElement>> get tableRows async {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Lists', 'tableRows');
     }
-    final returnMe = new PageObjectList<PageLoaderElement>(
-        $__root__.createList(const ByTagName('tr'), [], []),
+    final returnMe = PageObjectList<PageLoaderElement>(
+        $__root__.createList(ByTagName('tr'), [], []),
         (PageLoaderElement e) => e);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Lists', 'tableRows');
@@ -44,8 +44,8 @@ class $$Lists {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Lists', 'tableRowsSync');
     }
-    final returnMe = new PageObjectList<PageLoaderElement>(
-        $__root__.createList(const ByTagName('tr'), [], []),
+    final returnMe = PageObjectList<PageLoaderElement>(
+        $__root__.createList(ByTagName('tr'), [], []),
         (PageLoaderElement e) => e);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Lists', 'tableRowsSync');
@@ -57,9 +57,9 @@ class $$Lists {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Lists', 'tableRowsSyncAsPO');
     }
-    final returnMe = new PageObjectList<RowPO>(
-        $__root__.createList(const ByTagName('tr'), [], []),
-        (PageLoaderElement e) => new RowPO.create(e));
+    final returnMe = PageObjectList<RowPO>(
+        $__root__.createList(ByTagName('tr'), [], []),
+        (PageLoaderElement e) => RowPO.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Lists', 'tableRowsSyncAsPO');
     }
@@ -71,10 +71,10 @@ class $$Lists {
 class $RowPO extends RowPO with $$RowPO {
   PageLoaderElement $__root__;
   $RowPO.create(PageLoaderElement currentContext) : $__root__ = currentContext {
-    $__root__.addCheckers([new CheckTag('tr')]);
+    $__root__.addCheckers([CheckTag('tr')]);
   }
   factory $RowPO.lookup(PageLoaderSource source) =>
-      new $RowPO.create(source.byTag('tr'));
+      $RowPO.create(source.byTag('tr'));
   static String get tagName => 'tr';
   bool get exists {
     for (final __listener in $__root__.listeners) {
@@ -90,7 +90,7 @@ class $RowPO extends RowPO with $$RowPO {
 
 class $$RowPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get _root {
     for (final __listener in $__root__.listeners) {

--- a/test/src/listeners.dart
+++ b/test/src/listeners.dart
@@ -32,27 +32,27 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('are shared with root element', () async {
-      root.addListeners([new TestListener('A')]);
+      root.addListeners([TestListener('A')]);
 
-      final page = new PageForSimpleTest.create(root);
+      final page = PageForSimpleTest.create(root);
 
       expect(root.listeners, hasLength(1));
       expect(page.rootElement.listeners, hasLength(1));
     });
 
     test('are shared with created page object', () async {
-      root.addListeners([new TestListener('A')]);
+      root.addListeners([TestListener('A')]);
 
-      final page = new PageForSimpleTest.create(root);
+      final page = PageForSimpleTest.create(root);
 
       expect(root.listeners, hasLength(1));
       expect(page.table.table.listeners, hasLength(1));
     });
 
     test('are shared with created list', () async {
-      root.addListeners([new TestListener('A')]);
+      root.addListeners([TestListener('A')]);
 
-      final page = new PageForSimpleTest.create(root);
+      final page = PageForSimpleTest.create(root);
 
       expect(root.listeners, hasLength(1));
       expect((await page.table.rows)[0].rootElement.listeners, hasLength(1));

--- a/test/src/mouse.dart
+++ b/test/src/mouse.dart
@@ -22,7 +22,7 @@ typedef PageLoaderElement GetNewContext();
 void runTests(GetNewContext contextGenerator) {
   group('mouse support', () {
     test('basically works', () async {
-      final page = new PageForMouseTest.create(contextGenerator());
+      final page = PageForMouseTest.create(contextGenerator());
       final mouse = page.mouse;
 
       await mouse.moveTo(page.element, 2, 2);
@@ -38,7 +38,7 @@ void runTests(GetNewContext contextGenerator) {
     }, testOn: 'vm');
 
     test('works with event target', () async {
-      final page = new PageForMouseTest.create(contextGenerator());
+      final page = PageForMouseTest.create(contextGenerator());
       final mouse = page.mouse;
 
       // make sure mouse is not on element;

--- a/test/src/mouse.dart
+++ b/test/src/mouse.dart
@@ -65,4 +65,13 @@ abstract class PageForMouseTest {
 
   @ById('mouse')
   PageLoaderElement get element;
+
+  @ById('mouse-top')
+  PageLoaderElement get topElement;
+
+  @ById('mouse-center')
+  PageLoaderElement get centerElement;
+
+  @ById('mouse-bottom')
+  PageLoaderElement get bottomElement;
 }

--- a/test/src/mouse.g.dart
+++ b/test/src/mouse.g.dart
@@ -26,13 +26,13 @@ class $PageForMouseTest extends PageForMouseTest with $$PageForMouseTest {
 
 class $$PageForMouseTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get element {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForMouseTest', 'element');
     }
-    final element = $__root__.createElement(const ById('mouse'), [], []);
+    final element = $__root__.createElement(ById('mouse'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForMouseTest', 'element');
@@ -44,7 +44,7 @@ class $$PageForMouseTest {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForMouseTest', 'topElement');
     }
-    final element = $__root__.createElement(const ById('mouse-top'), [], []);
+    final element = $__root__.createElement(ById('mouse-top'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForMouseTest', 'topElement');
@@ -56,7 +56,7 @@ class $$PageForMouseTest {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForMouseTest', 'centerElement');
     }
-    final element = $__root__.createElement(const ById('mouse-center'), [], []);
+    final element = $__root__.createElement(ById('mouse-center'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForMouseTest', 'centerElement');
@@ -68,7 +68,7 @@ class $$PageForMouseTest {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForMouseTest', 'bottomElement');
     }
-    final element = $__root__.createElement(const ById('mouse-bottom'), [], []);
+    final element = $__root__.createElement(ById('mouse-bottom'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForMouseTest', 'bottomElement');

--- a/test/src/mouse.g.dart
+++ b/test/src/mouse.g.dart
@@ -16,6 +16,12 @@ class $PageForMouseTest extends PageForMouseTest with $$PageForMouseTest {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $PageForMouseTest.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "PageForMouseTest is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "PageForMouseTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$PageForMouseTest {
@@ -30,6 +36,42 @@ class $$PageForMouseTest {
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForMouseTest', 'element');
+    }
+    return returnMe;
+  }
+
+  PageLoaderElement get topElement {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('PageForMouseTest', 'topElement');
+    }
+    final element = $__root__.createElement(const ById('mouse-top'), [], []);
+    final returnMe = element;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('PageForMouseTest', 'topElement');
+    }
+    return returnMe;
+  }
+
+  PageLoaderElement get centerElement {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('PageForMouseTest', 'centerElement');
+    }
+    final element = $__root__.createElement(const ById('mouse-center'), [], []);
+    final returnMe = element;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('PageForMouseTest', 'centerElement');
+    }
+    return returnMe;
+  }
+
+  PageLoaderElement get bottomElement {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('PageForMouseTest', 'bottomElement');
+    }
+    final element = $__root__.createElement(const ById('mouse-bottom'), [], []);
+    final returnMe = element;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('PageForMouseTest', 'bottomElement');
     }
     return returnMe;
   }

--- a/test/src/properties.dart
+++ b/test/src/properties.dart
@@ -21,74 +21,74 @@ typedef PageLoaderElement GetNewContext();
 void runTests(GetNewContext contextGenerator) {
   group('properties', () {
     test('checked', () async {
-      final page = new PageForPropertiesTests.create(contextGenerator());
+      final page = PageForPropertiesTests.create(contextGenerator());
       expect(page.checkbox.properties['checked'], 'false');
       await page.checkbox.click();
       expect(page.checkbox.properties['checked'], 'true');
     });
 
     test('disabled', () async {
-      final page = new PageForPropertiesTests.create(contextGenerator());
+      final page = PageForPropertiesTests.create(contextGenerator());
       expect(page.readOnly.properties['disabled'], 'true');
       expect(page.text.properties['disabled'], 'false');
     });
 
     test('not a property', () async {
-      final page = new PageForPropertiesTests.create(contextGenerator());
+      final page = PageForPropertiesTests.create(contextGenerator());
       expect(page.table.properties['non-standard'], isNull);
     });
 
     test('option values', () async {
-      final page = new PageForPropertiesTests.create(contextGenerator());
+      final page = PageForPropertiesTests.create(contextGenerator());
 
       expect(page.option1.properties['value'], 'value 1');
       expect(page.option2.properties['value'], 'value 2');
     });
 
     test('option selected', () async {
-      final page = new PageForPropertiesTests.create(contextGenerator());
+      final page = PageForPropertiesTests.create(contextGenerator());
       await page.option2.click();
       expect(page.select1.properties['value'], equals('value 2'));
     });
 
     test('selected on checkbox', () async {
-      final page = new PageForPropertiesTests.create(contextGenerator());
+      final page = PageForPropertiesTests.create(contextGenerator());
       expect(page.checkbox.properties['checked'], 'false');
       await page.checkbox.click();
       expect(page.checkbox.properties['checked'], 'true');
     });
 
     test('selected on radio', () async {
-      final page = new PageForPropertiesTests.create(contextGenerator());
+      final page = PageForPropertiesTests.create(contextGenerator());
       expect(page.radio.properties['checked'], 'false');
       await page.radio.click();
       expect(page.radio.properties['checked'], 'true');
     });
 
     test('href on a', () async {
-      final page = new PageForPropertiesTests.create(contextGenerator());
+      final page = PageForPropertiesTests.create(contextGenerator());
       expect(page.anchor.properties['href'], endsWith('/test.html'));
     });
 
     test('src on img', () async {
-      final page = new PageForPropertiesTests.create(contextGenerator());
+      final page = PageForPropertiesTests.create(contextGenerator());
       expect(page.img.properties['src'], endsWith('/test.png'));
     });
 
     test('class/className', () async {
-      final page = new PageForPropertiesTests.create(contextGenerator());
+      final page = PageForPropertiesTests.create(contextGenerator());
       expect(page.table.properties['class'], isNull);
       expect(page.table.properties['className'], 'class1 class2 class3');
     });
 
     test('readonly/readOnly', () async {
-      final page = new PageForPropertiesTests.create(contextGenerator());
+      final page = PageForPropertiesTests.create(contextGenerator());
       expect(page.readOnly.properties['readOnly'], 'true');
       expect(page.text.properties['readOnly'], 'false');
     });
 
     test('value on text', () async {
-      final page = new PageForPropertiesTests.create(contextGenerator());
+      final page = PageForPropertiesTests.create(contextGenerator());
       expect(page.text.properties['value'], '');
       await page.text.type('some text');
       expect(page.text.properties['value'], 'some text');

--- a/test/src/properties.g.dart
+++ b/test/src/properties.g.dart
@@ -17,6 +17,12 @@ class $PageForPropertiesTests extends PageForPropertiesTests
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $PageForPropertiesTests.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "PageForPropertiesTests is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "PageForPropertiesTests". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$PageForPropertiesTests {

--- a/test/src/properties.g.dart
+++ b/test/src/properties.g.dart
@@ -27,14 +27,14 @@ class $PageForPropertiesTests extends PageForPropertiesTests
 
 class $$PageForPropertiesTests {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get divWithStyle {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod(
           'PageForPropertiesTests', 'divWithStyle');
     }
-    final element = $__root__.createElement(const ById('div'), [], []);
+    final element = $__root__.createElement(ById('div'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForPropertiesTests', 'divWithStyle');
@@ -47,7 +47,7 @@ class $$PageForPropertiesTests {
       __listener.startPageObjectMethod('PageForPropertiesTests', 'checkbox');
     }
     final element =
-        $__root__.createElement(const ByCss('input[type=checkbox]'), [], []);
+        $__root__.createElement(ByCss('input[type=checkbox]'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForPropertiesTests', 'checkbox');
@@ -59,7 +59,7 @@ class $$PageForPropertiesTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForPropertiesTests', 'table');
     }
-    final element = $__root__.createElement(const ById('table1'), [], []);
+    final element = $__root__.createElement(ById('table1'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForPropertiesTests', 'table');
@@ -71,7 +71,7 @@ class $$PageForPropertiesTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForPropertiesTests', 'select1');
     }
-    final element = $__root__.createElement(const ById('select1'), [], []);
+    final element = $__root__.createElement(ById('select1'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForPropertiesTests', 'select1');
@@ -83,7 +83,7 @@ class $$PageForPropertiesTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForPropertiesTests', 'option1');
     }
-    final element = $__root__.createElement(const ById('option1'), [], []);
+    final element = $__root__.createElement(ById('option1'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForPropertiesTests', 'option1');
@@ -95,7 +95,7 @@ class $$PageForPropertiesTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForPropertiesTests', 'option2');
     }
-    final element = $__root__.createElement(const ById('option2'), [], []);
+    final element = $__root__.createElement(ById('option2'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForPropertiesTests', 'option2');
@@ -108,7 +108,7 @@ class $$PageForPropertiesTests {
       __listener.startPageObjectMethod('PageForPropertiesTests', 'radio');
     }
     final element =
-        $__root__.createElement(const ByCss('input[value=radio1]'), [], []);
+        $__root__.createElement(ByCss('input[value=radio1]'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForPropertiesTests', 'radio');
@@ -120,7 +120,7 @@ class $$PageForPropertiesTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForPropertiesTests', 'anchor');
     }
-    final element = $__root__.createElement(const ById('anchor'), [], []);
+    final element = $__root__.createElement(ById('anchor'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForPropertiesTests', 'anchor');
@@ -132,7 +132,7 @@ class $$PageForPropertiesTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForPropertiesTests', 'img');
     }
-    final element = $__root__.createElement(const ByTagName('img'), [], []);
+    final element = $__root__.createElement(ByTagName('img'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForPropertiesTests', 'img');
@@ -144,7 +144,7 @@ class $$PageForPropertiesTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForPropertiesTests', 'readOnly');
     }
-    final element = $__root__.createElement(const ById('readonly'), [], []);
+    final element = $__root__.createElement(ById('readonly'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForPropertiesTests', 'readOnly');
@@ -156,7 +156,7 @@ class $$PageForPropertiesTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForPropertiesTests', 'text');
     }
-    final element = $__root__.createElement(const ById('text'), [], []);
+    final element = $__root__.createElement(ById('text'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForPropertiesTests', 'text');

--- a/test/src/shared_list_page_objects.g.dart
+++ b/test/src/shared_list_page_objects.g.dart
@@ -26,7 +26,7 @@ class $PageForSimpleTest extends PageForSimpleTest with $$PageForSimpleTest {
 
 class $$PageForSimpleTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get rootElement {
     for (final __listener in $__root__.listeners) {
@@ -44,8 +44,8 @@ class $$PageForSimpleTest {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForSimpleTest', 'table');
     }
-    final element = $__root__.createElement(const ByTagName('table'), [], []);
-    final returnMe = new Table.create(element);
+    final element = $__root__.createElement(ByTagName('table'), [], []);
+    final returnMe = Table.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForSimpleTest', 'table');
     }
@@ -69,7 +69,7 @@ class $Table extends Table with $$Table {
 
 class $$Table {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get table {
     for (final __listener in $__root__.listeners) {
@@ -87,9 +87,9 @@ class $$Table {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Table', 'rows');
     }
-    final returnMe = new PageObjectList<Row>(
-        $__root__.createList(const ByTagName('tr'), [], []),
-        (PageLoaderElement e) => new Row.create(e));
+    final returnMe = PageObjectList<Row>(
+        $__root__.createList(ByTagName('tr'), [], []),
+        (PageLoaderElement e) => Row.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Table', 'rows');
     }
@@ -100,9 +100,9 @@ class $$Table {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Table', 'rowsSync');
     }
-    final returnMe = new PageObjectList<Row>(
-        $__root__.createList(const ByTagName('tr'), [], []),
-        (PageLoaderElement e) => new Row.create(e));
+    final returnMe = PageObjectList<Row>(
+        $__root__.createList(ByTagName('tr'), [], []),
+        (PageLoaderElement e) => Row.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Table', 'rowsSync');
     }
@@ -126,7 +126,7 @@ class $Row extends Row with $$Row {
 
 class $$Row {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get rootElement {
     for (final __listener in $__root__.listeners) {
@@ -144,8 +144,8 @@ class $$Row {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Row', 'cells');
     }
-    final returnMe = new PageObjectList<PageLoaderElement>(
-        $__root__.createList(const ByTagName('td'), [], []),
+    final returnMe = PageObjectList<PageLoaderElement>(
+        $__root__.createList(ByTagName('td'), [], []),
         (PageLoaderElement e) => e);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Row', 'cells');

--- a/test/src/shared_list_page_objects.g.dart
+++ b/test/src/shared_list_page_objects.g.dart
@@ -16,6 +16,12 @@ class $PageForSimpleTest extends PageForSimpleTest with $$PageForSimpleTest {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $PageForSimpleTest.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "PageForSimpleTest is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "PageForSimpleTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$PageForSimpleTest {
@@ -53,6 +59,12 @@ class $Table extends Table with $$Table {
   $Table.create(PageLoaderElement currentContext) : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Table.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Table is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Table". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$Table {
@@ -104,6 +116,12 @@ class $Row extends Row with $$Row {
   $Row.create(PageLoaderElement currentContext) : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Row.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Row is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Row". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$Row {

--- a/test/src/shared_page_objects.dart
+++ b/test/src/shared_page_objects.dart
@@ -40,7 +40,7 @@ abstract class Table {
   PageObjectIterable<Row> get rows;
 
   Future doSlowAction() async {
-    return new Future.delayed(new Duration(seconds: 5));
+    return Future.delayed(Duration(seconds: 5));
   }
 }
 

--- a/test/src/shared_page_objects.g.dart
+++ b/test/src/shared_page_objects.g.dart
@@ -26,14 +26,14 @@ class $PageForSimpleTest extends PageForSimpleTest with $$PageForSimpleTest {
 
 class $$PageForSimpleTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   Table get table {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForSimpleTest', 'table');
     }
-    final element = $__root__.createElement(const ByTagName('table'), [], []);
-    final returnMe = new Table.create(element);
+    final element = $__root__.createElement(ByTagName('table'), [], []);
+    final returnMe = Table.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForSimpleTest', 'table');
     }
@@ -67,7 +67,7 @@ class $Table extends Table with $$Table {
 
 class $$Table {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get table {
     for (final __listener in $__root__.listeners) {
@@ -85,9 +85,9 @@ class $$Table {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Table', 'rows');
     }
-    final returnMe = new PageObjectIterable<Row>(
-        $__root__.createIterable(const ByTagName('tr'), [], []),
-        (PageLoaderElement e) => new Row.create(e));
+    final returnMe = PageObjectIterable<Row>(
+        $__root__.createIterable(ByTagName('tr'), [], []),
+        (PageLoaderElement e) => Row.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Table', 'rows');
     }
@@ -111,14 +111,14 @@ class $Row extends Row with $$Row {
 
 class $$Row {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageObjectIterable<PageLoaderElement> get cells {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Row', 'cells');
     }
-    final returnMe = new PageObjectIterable<PageLoaderElement>(
-        $__root__.createIterable(const ByTagName('td'), [], []),
+    final returnMe = PageObjectIterable<PageLoaderElement>(
+        $__root__.createIterable(ByTagName('td'), [], []),
         (PageLoaderElement e) => e);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Row', 'cells');

--- a/test/src/shared_page_objects.g.dart
+++ b/test/src/shared_page_objects.g.dart
@@ -16,6 +16,12 @@ class $PageForSimpleTest extends PageForSimpleTest with $$PageForSimpleTest {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $PageForSimpleTest.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "PageForSimpleTest is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "PageForSimpleTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$PageForSimpleTest {
@@ -41,6 +47,12 @@ class $Table extends Table with $$Table {
   $Table.create(PageLoaderElement currentContext) : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Table.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Table is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Table". Requires @CheckTag annotation in order for "tagName" to be generated.';
   Future doSlowAction() {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Table', 'doSlowAction');
@@ -89,6 +101,12 @@ class $Row extends Row with $$Row {
   $Row.create(PageLoaderElement currentContext) : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $Row.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "Row is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "Row". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$Row {

--- a/test/src/source_support.dart
+++ b/test/src/source_support.dart
@@ -49,9 +49,9 @@ class _SomePageObject_ { $methodDeclaration }
 @CheckTag('demo-checked')
 class DemoCheckedPO {}
 ''';
-  final driver = new TestDriver();
+  final driver = TestDriver();
   final unit = await driver.resultForFile('test_mock.dart', classToParse);
-  final finder = new MethodFinder(methodName);
+  final finder = MethodFinder(methodName);
   unit.accept(finder);
 
   return finder.method;
@@ -83,35 +83,34 @@ class TestDriver {
   /// Root path on all scoped files.
   final String root = '/test/root/path';
 
-  final ResourceProvider resourceProvider = new MemoryResourceProvider();
+  final ResourceProvider resourceProvider = MemoryResourceProvider();
 
   CompilationUnit get compilationUnit => _compilationUnit;
 
   Future<TypeProvider> get typeProvider => session.typeProvider;
 
   TestDriver() {
-    final byteStore = new MemoryByteStore();
-    final sdk = new MockSdk(resourceProvider: resourceProvider);
+    final byteStore = MemoryByteStore();
+    final sdk = MockSdk(resourceProvider: resourceProvider);
     final resolvers = [
-      new DartUriResolver(sdk),
-      new ResourceUriResolver(resourceProvider),
+      DartUriResolver(sdk),
+      ResourceUriResolver(resourceProvider),
     ];
 
-    final logger = new PerformanceLog(new StringBuffer());
-    final scheduler = new AnalysisDriverScheduler(logger)..start();
-    final allResolvers = <UriResolver>[new DartUriResolver(sdk)]
-      ..addAll(resolvers);
-    final sourceFactory = new SourceFactory(allResolvers);
+    final logger = PerformanceLog(StringBuffer());
+    final scheduler = AnalysisDriverScheduler(logger)..start();
+    final allResolvers = <UriResolver>[DartUriResolver(sdk)]..addAll(resolvers);
+    final sourceFactory = SourceFactory(allResolvers);
 
-    driver = new AnalysisDriver(
+    driver = AnalysisDriver(
       scheduler,
       logger,
       resourceProvider,
       byteStore,
-      new FileContentOverlay(),
+      FileContentOverlay(),
       null, // ContextRoot
       sourceFactory,
-      new AnalysisOptionsImpl()..strongMode = true,
+      AnalysisOptionsImpl()..strongMode = true,
     );
     session = driver.currentSession;
 

--- a/test/src/typing.dart
+++ b/test/src/typing.dart
@@ -21,7 +21,7 @@ typedef PageLoaderElement GetNewContext();
 void runTests(GetNewContext contextGenerator) {
   group('typing', () {
     test('Type into textarea', () async {
-      final page = new PageForTextAreaTypingText.create(contextGenerator());
+      final page = PageForTextAreaTypingText.create(contextGenerator());
       await page.textArea.type('some');
       expect(page.textArea.properties['value'], 'some');
       await page.textArea.type(' string');
@@ -31,7 +31,7 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('typing should append', () async {
-      final page = new PageForTypingTests.create(contextGenerator());
+      final page = PageForTypingTests.create(contextGenerator());
       expect(page.text.properties['value'], '');
       await page.text.type('some text');
       expect(page.text.properties['value'], 'some text');
@@ -40,7 +40,7 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('value after clear', () async {
-      final page = new PageForTypingTests.create(contextGenerator());
+      final page = PageForTypingTests.create(contextGenerator());
       expect(page.text.properties['value'], '');
       await page.text.type('some text');
       expect(page.text.properties['value'], 'some text');

--- a/test/src/typing.g.dart
+++ b/test/src/typing.g.dart
@@ -17,6 +17,12 @@ class $PageForTextAreaTypingText extends PageForTextAreaTypingText
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $PageForTextAreaTypingText.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "PageForTextAreaTypingText is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "PageForTextAreaTypingText". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$PageForTextAreaTypingText {
@@ -43,6 +49,12 @@ class $PageForTypingTests extends PageForTypingTests with $$PageForTypingTests {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $PageForTypingTests.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "PageForTypingTests is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "PageForTypingTests". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$PageForTypingTests {

--- a/test/src/typing.g.dart
+++ b/test/src/typing.g.dart
@@ -27,13 +27,13 @@ class $PageForTextAreaTypingText extends PageForTextAreaTypingText
 
 class $$PageForTextAreaTypingText {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get textArea {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForTextAreaTypingText', 'textArea');
     }
-    final element = $__root__.createElement(const ById('textarea'), [], []);
+    final element = $__root__.createElement(ById('textarea'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForTextAreaTypingText', 'textArea');
@@ -59,13 +59,13 @@ class $PageForTypingTests extends PageForTypingTests with $$PageForTypingTests {
 
 class $$PageForTypingTests {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get text {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForTypingTests', 'text');
     }
-    final element = $__root__.createElement(const ById('text'), [], []);
+    final element = $__root__.createElement(ById('text'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForTypingTests', 'text');

--- a/test/src/webdriver_only.dart
+++ b/test/src/webdriver_only.dart
@@ -25,15 +25,19 @@ void runTests(GetNewContext contextGenerator) {
   group('webdriver ', () {
     test('computes offset sensibly', () async {
       final webdriverOnly = new WebDriverOnly.create(contextGenerator());
-      expect(webdriverOnly.button1.offset.width, greaterThan(300));
-      expect(webdriverOnly.button1.offset.height, greaterThan(300));
+      expect(webdriverOnly.button1.offset.width, greaterThan(80));
+      expect(webdriverOnly.button1.offset.width, lessThan(150));
+      expect(webdriverOnly.button1.offset.height, greaterThan(10));
+      expect(webdriverOnly.button1.offset.height, lessThan(40));
     });
 
     test('computes bounding rect sensibly', () async {
       final webdriverOnly = new WebDriverOnly.create(contextGenerator());
       final boundingRect = webdriverOnly.button1.getBoundingClientRect();
-      expect(boundingRect.height, greaterThan(300));
-      expect(boundingRect.width, greaterThan(300));
+      expect(boundingRect.width, greaterThan(80));
+      expect(boundingRect.width, lessThan(150));
+      expect(boundingRect.height, greaterThan(10));
+      expect(boundingRect.height, lessThan(40));
     });
   });
 }

--- a/test/src/webdriver_only.dart
+++ b/test/src/webdriver_only.dart
@@ -24,7 +24,7 @@ typedef void DoRefresh();
 void runTests(GetNewContext contextGenerator) {
   group('webdriver ', () {
     test('computes offset sensibly', () async {
-      final webdriverOnly = new WebDriverOnly.create(contextGenerator());
+      final webdriverOnly = WebDriverOnly.create(contextGenerator());
       expect(webdriverOnly.button1.offset.width, greaterThan(80));
       expect(webdriverOnly.button1.offset.width, lessThan(150));
       expect(webdriverOnly.button1.offset.height, greaterThan(10));
@@ -32,7 +32,7 @@ void runTests(GetNewContext contextGenerator) {
     });
 
     test('computes bounding rect sensibly', () async {
-      final webdriverOnly = new WebDriverOnly.create(contextGenerator());
+      final webdriverOnly = WebDriverOnly.create(contextGenerator());
       final boundingRect = webdriverOnly.button1.getBoundingClientRect();
       expect(boundingRect.width, greaterThan(80));
       expect(boundingRect.width, lessThan(150));

--- a/test/src/webdriver_only.g.dart
+++ b/test/src/webdriver_only.g.dart
@@ -26,13 +26,13 @@ class $WebDriverOnly extends WebDriverOnly with $$WebDriverOnly {
 
 class $$WebDriverOnly {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
+  PageLoaderMouse __mouse__; // ignore: unused_field
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get button1 {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('WebDriverOnly', 'button1');
     }
-    final element = $__root__.createElement(const ById('button-1'), [], []);
+    final element = $__root__.createElement(ById('button-1'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('WebDriverOnly', 'button1');

--- a/test/src/webdriver_only.g.dart
+++ b/test/src/webdriver_only.g.dart
@@ -16,6 +16,12 @@ class $WebDriverOnly extends WebDriverOnly with $$WebDriverOnly {
       : $__root__ = currentContext {
     $__root__.addCheckers([]);
   }
+  factory $WebDriverOnly.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+      "WebDriverOnly is not generated and can only be used on Page Object "
+      "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "WebDriverOnly". Requires @CheckTag annotation in order for "tagName" to be generated.';
 }
 
 class $$WebDriverOnly {

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -16,7 +16,7 @@ import 'package:test/test.dart';
 
 // Test failures only; successes are tested in matchers_test.dart
 void main() {
-  final utilsError = throwsA(new TypeMatcher<PageLoaderArgumentError>());
+  final utilsError = throwsA(TypeMatcher<PageLoaderArgumentError>());
   final foo = 'foo';
 
   test('exists fails', () {

--- a/test/webdriver_annotations_test.dart
+++ b/test/webdriver_annotations_test.dart
@@ -17,7 +17,7 @@ import 'setup/webdriver_environment.dart';
 import 'src/annotations.dart' as annotations;
 
 void main() {
-  final environment = new WebDriverEnvironment();
+  final environment = WebDriverEnvironment();
   setUp(environment.setUp);
   tearDown(environment.tearDown);
   annotations.runTests(() => environment.getBaseElement());

--- a/test/webdriver_attributes_test.dart
+++ b/test/webdriver_attributes_test.dart
@@ -17,7 +17,7 @@ import 'setup/webdriver_environment.dart';
 import 'src/attributes.dart' as attributes;
 
 void main() {
-  final environment = new WebDriverEnvironment();
+  final environment = WebDriverEnvironment();
   setUp(environment.setUp);
   tearDown(environment.tearDown);
   attributes.runTests(() => environment.getBaseElement());

--- a/test/webdriver_basic_test.dart
+++ b/test/webdriver_basic_test.dart
@@ -17,7 +17,7 @@ import 'setup/webdriver_environment.dart';
 import 'src/basic.dart' as basic;
 
 void main() {
-  final environment = new WebDriverEnvironment();
+  final environment = WebDriverEnvironment();
   setUp(environment.setUp);
   tearDown(environment.tearDown);
   basic.runTests(() => environment.getBaseElement());

--- a/test/webdriver_cache_invalidation_test.dart
+++ b/test/webdriver_cache_invalidation_test.dart
@@ -17,7 +17,7 @@ import 'setup/webdriver_environment.dart';
 import 'src/cache_invalidation.dart' as cache_invalidation;
 
 void main() {
-  final environment = new WebDriverEnvironment();
+  final environment = WebDriverEnvironment();
   setUp(environment.setUp);
   tearDown(environment.tearDown);
   cache_invalidation.runTests(

--- a/test/webdriver_constructors_test.dart
+++ b/test/webdriver_constructors_test.dart
@@ -17,7 +17,7 @@ import 'setup/webdriver_environment.dart';
 import 'src/constructors.dart' as constructors;
 
 void main() {
-  final environment = new WebDriverEnvironment();
+  final environment = WebDriverEnvironment();
   setUp(environment.setUp);
   tearDown(environment.tearDown);
   constructors.runTests(() => environment.getBaseElement());

--- a/test/webdriver_constructors_test.dart
+++ b/test/webdriver_constructors_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All rights reserved.
+// Copyright 2018 Google Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,17 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library pageloader.api.page_loader_interface;
+import 'package:test/test.dart';
 
-import 'page_loader_element_interface.dart';
-import 'page_loader_mouse_interface.dart';
-import 'page_loader_source_interface.dart';
+import 'setup/webdriver_environment.dart';
+import 'src/constructors.dart' as constructors;
 
-/// Convenience methods that vary based on environment.
-abstract class PageUtils extends PageLoaderSource {
-  /// Gets the current root element for the DOM. Used to create page objects.
-  PageLoaderElement get root;
-
-  /// Gets the mouse.
-  PageLoaderMouse get mouse;
+void main() {
+  final environment = new WebDriverEnvironment();
+  setUp(environment.setUp);
+  tearDown(environment.tearDown);
+  constructors.runTests(() => environment.getBaseElement());
 }

--- a/test/webdriver_generics_test.dart
+++ b/test/webdriver_generics_test.dart
@@ -17,7 +17,7 @@ import 'setup/webdriver_environment.dart';
 import 'src/generics.dart' as generics;
 
 void main() {
-  final environment = new WebDriverEnvironment();
+  final environment = WebDriverEnvironment();
   setUp(environment.setUp);
   tearDown(environment.tearDown);
   generics.runTests(() => environment.getBaseElement());

--- a/test/webdriver_list_test.dart
+++ b/test/webdriver_list_test.dart
@@ -17,7 +17,7 @@ import 'setup/webdriver_environment.dart';
 import 'src/list.dart' as list;
 
 void main() {
-  final environment = new WebDriverEnvironment();
+  final environment = WebDriverEnvironment();
   setUp(environment.setUp);
   tearDown(environment.tearDown);
   list.runTests(() => environment.getBaseElement());

--- a/test/webdriver_listener_test.dart
+++ b/test/webdriver_listener_test.dart
@@ -17,7 +17,7 @@ import 'setup/webdriver_environment.dart';
 import 'src/listeners.dart' as listeners;
 
 void main() {
-  final environment = new WebDriverEnvironment();
+  final environment = WebDriverEnvironment();
   setUp(environment.setUp);
   tearDown(environment.tearDown);
   listeners.runTests(() => environment.getBaseElement());

--- a/test/webdriver_mouse_test.dart
+++ b/test/webdriver_mouse_test.dart
@@ -17,7 +17,7 @@ import 'setup/webdriver_environment.dart';
 import 'src/mouse.dart' as mouse;
 
 void main() {
-  final environment = new WebDriverEnvironment();
+  final environment = WebDriverEnvironment();
   setUp(environment.setUp);
   tearDown(environment.tearDown);
   mouse.runTests(() => environment.getBaseElement());

--- a/test/webdriver_only_test.dart
+++ b/test/webdriver_only_test.dart
@@ -17,7 +17,7 @@ import 'setup/webdriver_environment.dart';
 import 'src/webdriver_only.dart' as webdriver_only;
 
 void main() {
-  final environment = new WebDriverEnvironment();
+  final environment = WebDriverEnvironment();
   setUp(environment.setUp);
   tearDown(environment.tearDown);
   webdriver_only.runTests(() => environment.getBaseElement());

--- a/test/webdriver_properties_test.dart
+++ b/test/webdriver_properties_test.dart
@@ -17,7 +17,7 @@ import 'setup/webdriver_environment.dart';
 import 'src/properties.dart' as properties;
 
 void main() {
-  final environment = new WebDriverEnvironment();
+  final environment = WebDriverEnvironment();
   setUp(environment.setUp);
   tearDown(environment.tearDown);
   properties.runTests(() => environment.getBaseElement());

--- a/test/webdriver_typing_test.dart
+++ b/test/webdriver_typing_test.dart
@@ -17,7 +17,7 @@ import 'setup/webdriver_environment.dart';
 import 'src/typing.dart' as typing;
 
 void main() {
-  final environment = new WebDriverEnvironment();
+  final environment = WebDriverEnvironment();
   setUp(environment.setUp);
   tearDown(environment.tearDown);
   typing.runTests(() => environment.getBaseElement());


### PR DESCRIPTION
Sync up with PageLoader updates that include:

- Add 'lookup' constructor that can also be delegated similar to 'create'.
- HtmlMouse is improved to provide more mouseevents that better simulate user mouse movements.
- Add 'clickOutside()' to PageLoaderElement
- Add ignore lint for 'unused_field' #144 
- Remove usage of unnecessary new and const #152 
- Bug fixes

Ignore the warning that 'mouse' is deprecated. Future release of webdriver will un-deprecate this.