### PR TITLE
Stop passing strong parameter to SummaryBuilder constructor.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   webdriver: ^2.0.0-beta
 
 dev_dependencies:
+  analyzer: ^0.32.5
   build_config: ^0.2.4
   build_runner: ^0.8.8
   built_value_generator: ^5.4.0

--- a/test/mocks/sdk.dart
+++ b/test/mocks/sdk.dart
@@ -623,9 +623,7 @@ class MockSdk implements DartSdk {
     final librarySources = sdkLibraries
         .map((SdkLibrary library) => mapDartUri(library.shortName))
         .toList();
-    return new SummaryBuilder(
-            librarySources, context, context.analysisOptions.strongMode)
-        .build();
+    return new SummaryBuilder(librarySources, context).build();
   }
 }
 


### PR DESCRIPTION
The analyzer only supports strong mode now, and analyzer version
0.33.* will remove this constructor parameter.  As of analyzer version
0.32.5, the parameter is optional, so we can stop passing it now.

Also fix the pubspec to include the analyzer as a dev_dependency
(necessary because tests use the analyzer directly).