### PR TITLE
Upgrade to analyzer 0.33.3

### DIFF
--- a/lib/src/generators/pageobject_generator.dart
+++ b/lib/src/generators/pageobject_generator.dart
@@ -50,7 +50,7 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
         // ignore: deprecated_member_use
         final parsedLibrary = ParsedLibraryResultImpl.tmp(element.library);
         final annotatedNode = parsedLibrary.getElementDeclaration(element).node;
-        return _generateClass(annotatedNode);
+        return _generateClass(element, annotatedNode);
       } catch (e, stackTrace) {
         log.warning('Failure generating class for ${element.library}! '
             '\n $e \n $stackTrace');
@@ -62,7 +62,7 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
     }
   }
 
-  String _generateClass(ClassDeclaration declaration) {
+  String _generateClass(ClassElement element, ClassDeclaration declaration) {
     final collectorVisitor = CollectorVisitor(declaration);
     declaration.visitChildren(collectorVisitor);
 
@@ -78,7 +78,7 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
 
     // Run check to make sure PO is not extending another PO.
     // Only mixins are allowed.
-    if (poExtendsAnotherPo(declaration.element)) {
+    if (poExtendsAnotherPo(element)) {
       throw Exception('******************\n\n'
           'Errors detected during code generation:\n\n'
           "PageObject class '${declaration.name.name}' is extending another "
@@ -89,8 +89,8 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
 
     // If PageObject has constructor, define constructor class with root
     // and start constructor.
-    if (hasPoConstructors(declaration.element)) {
-      final withClause = generateWithClause(declaration.element, signatureArgs);
+    if (hasPoConstructors(element)) {
+      final withClause = generateWithClause(element, signatureArgs);
       constructorBuffer.write('''
       class \$$signature extends $signatureArgs $withClause {
         PageLoaderElement ${core.root};

--- a/lib/src/generators/pageobject_generator.dart
+++ b/lib/src/generators/pageobject_generator.dart
@@ -15,6 +15,8 @@ import 'dart:async';
 
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/element/element.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/dart/analysis/results.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -43,9 +45,11 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
   @override
   Future<String> generateForAnnotatedElement(
       Element element, ConstantReader annotation, BuildStep buildStep) async {
-    final annotatedNode = element.computeNode();
-    if (annotatedNode is ClassDeclaration) {
+    if (element is ClassElement) {
       try {
+        // ignore: deprecated_member_use
+        final parsedLibrary = ParsedLibraryResultImpl.tmp(element.library);
+        final annotatedNode = parsedLibrary.getElementDeclaration(element).node;
         return _generateClass(annotatedNode);
       } catch (e, stackTrace) {
         log.warning('Failure generating class for ${element.library}! '
@@ -54,7 +58,7 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
       }
     } else {
       throw '@PageObject() can only be applied to classes, '
-          'not type: ${annotatedNode.runtimeType}';
+          'not type: ${element.runtimeType}';
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.32.5
+  analyzer: ^0.33.3
   build: '>0.12.7 <2.0.0'
   build_config: ^0.3.1
   built_value: ^6.1.0


### PR DESCRIPTION
Switch to use a temporary `ParsedLibraryResult` API until the final API
is worked out in `package:build`. The current approach of using
`computeNode()` will break in the next breaking release of `build` when
it flips to using `AnalysisDriver` isntead of `AnalysisContext` to back
the `Resolver`. This temporary API will allow backwards compatibility
until the migration is complete.