### PR TITLE
Fix `PageLoaderElement.innerText` doc.

### DIFF
--- a/lib/src/api/page_loader_element_interface.dart
+++ b/lib/src/api/page_loader_element_interface.dart
@@ -65,17 +65,17 @@ abstract class PageLoaderElement extends PageLoaderSource {
   /// The shadow root hosted by this element.
   PageLoaderElement get shadowRoot;
 
-  /// The text content of this element.
+  /// The inner text of this element.
   ///
-  /// This should return the value of `<element>.innerText` (see
-  /// https://developer.mozilla.org/en-US/docs/Web/API/Node/innerText), but
-  /// behaviour may vary for the different pageloader implementations.
+  /// This should return the value of
+  /// [`<element>.innerText`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText),
+  /// but behaviour may vary for the different pageloader implementations.
   String get innerText;
 
   /// Visible text within this element.
   ///
-  /// This should return the value of webdriver's getText() call (see
-  /// http://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/WebElement.html#getText--),
+  /// This should return the value of webdriver's
+  /// [`getText()`](http://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/WebElement.html#getText--),
   /// but behaviour may vary for the different pageloader implementations.
   String get visibleText;
 

--- a/lib/src/api/page_loader_element_interface.dart
+++ b/lib/src/api/page_loader_element_interface.dart
@@ -67,15 +67,15 @@ abstract class PageLoaderElement extends PageLoaderSource {
 
   /// The inner text of this element.
   ///
-  /// This should return the value of
-  /// [`<element>.innerText`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText),
+  /// This should return the value of [`<element>.innerText`](
+  /// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText),
   /// but behaviour may vary for the different pageloader implementations.
   String get innerText;
 
   /// Visible text within this element.
   ///
-  /// This should return the value of webdriver's
-  /// [`getText()`](http://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/WebElement.html#getText--),
+  /// This should return the value of webdriver's [`getText()`](
+  /// http://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/WebElement.html#getText--),
   /// but behaviour may vary for the different pageloader implementations.
   String get visibleText;
 


### PR DESCRIPTION
*   Change `text content` => `inner text` (textContent is a different element property)
*   Update link

Part of https://github.com/google/pageloader/issues/166