### PR TITLE
Bump analyzer to 0.34

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.33.0 <=0.34.0'
+  analyzer: '>=0.33.0 <0.35.0'
   build: '>0.12.7 <2.0.0'
   build_config: ^0.3.1
   built_value: ^6.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.34.0
+  analyzer: '>=0.33.0 <=0.34.0'
   build: '>0.12.7 <2.0.0'
   build_config: ^0.3.1
   built_value: ^6.1.0
@@ -28,6 +28,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.0.0
-  built_value_generator: ^6.0.0
+  built_value_generator: ^6.2.0
   path: ^1.3.6
   test: ^1.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.33.3
+  analyzer: ^0.34.0
   build: '>0.12.7 <2.0.0'
   build_config: ^0.3.1
   built_value: ^6.1.0


### PR DESCRIPTION
Looks like I can't use a solid ^0.34.0 due to built_value_generator. This should be a good middle ground solution until that is also bumped as well. #169 