### PR TITLE
Bump SDK and analyzer version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.2.0
+
+- Allow `analyzer` version `0.36.x`.
+- Require Dart SDK `>=2.2.0`.
+
 ## 3.1.1
 
 - Generated `tagName` getter is now const if valid, getter if not valid.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,10 +14,10 @@ description:
 homepage: https://github.com/google/pageloader
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.2.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.33.0 <0.35.0'
+  analyzer: '>=0.33.0 <0.37.0'
   build: '>0.12.7 <2.0.0'
   build_config: ^0.3.1
   built_value: ^6.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pageloader
 
-version: 3.1.1
+version: 3.2.0
 
 authors:
   - Marc Fisher II (emeritus) <fisherii@google.com>
@@ -17,7 +17,7 @@ environment:
   sdk: '>=2.2.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.33.0 <0.37.0'
+  analyzer: '>=0.35.0 <0.37.0'
   build: '>0.12.7 <2.0.0'
   build_config: ^0.3.1
   built_value: ^6.1.0


### PR DESCRIPTION
I'm skipping from `>=2.0.0` to `>=2.2.0`, do you think this is fine Kevin? Or should I add an intermediary version for `>=2.1.0`?