### PR TITLE
Create a @ByTestId annotation that selects element with attribute "data-test-id".

### DIFF
--- a/lib/src/api/annotations.dart
+++ b/lib/src/api/annotations.dart
@@ -171,6 +171,43 @@ class ByDebugId implements CssFinder {
   String toString() => '@ByDebugId("$_debugId")';
 }
 
+/// Finds element by data-test-id attribute.
+///
+/// To use this annotation, add a [data-test-id] HTML attribute to the element
+/// you wish to select. This assigns a test-only ID to the element so this
+/// annotation can target select that element.
+///
+/// For more detailed explaination and rationales,
+/// please see go/change-resilient-ui-testing-dd or
+/// https://kentcdodds.com/blog/making-your-ui-tests-resilient-to-change
+///
+/// Example:
+///
+/// ```html
+/// <button data-test-id="cancel-button">
+/// <button data-test-id="submit-button">
+/// ```
+///
+/// Then these button can be selected as follow:
+/// ```dart
+/// @ByTestId("cancel-button")
+/// MaterialButtonPO get cancelButton;
+///
+/// @ByTestId("submit-button")
+/// MaterialButtonPO get submitButton;
+/// ```
+class ByTestId implements CssFinder {
+  final String _testId;
+
+  const ByTestId(this._testId);
+
+  @override
+  String get cssSelector => '[data-test-id="$_testId"]';
+
+  @override
+  String toString() => '@ByTestId("$_testId")';
+}
+
 /// Finds element by ID.
 class ById implements CssFinder {
   final String _id;

--- a/lib/src/api/annotations.dart
+++ b/lib/src/api/annotations.dart
@@ -171,9 +171,9 @@ class ByDebugId implements CssFinder {
   String toString() => '@ByDebugId("$_debugId")';
 }
 
-/// Finds element by 'data-test-id' attribute.
+/// Finds element by data-test-id attribute.
 ///
-/// To use this annotation, add a 'data-test-id' HTML attribute to the element
+/// To use this annotation, add a [data-test-id] HTML attribute to the element
 /// you wish to select. This assigns a test-only ID to the element so this
 /// annotation can target select that element.
 ///

--- a/lib/src/api/annotations.dart
+++ b/lib/src/api/annotations.dart
@@ -171,9 +171,9 @@ class ByDebugId implements CssFinder {
   String toString() => '@ByDebugId("$_debugId")';
 }
 
-/// Finds element by data-test-id attribute.
+/// Finds element by 'data-test-id' attribute.
 ///
-/// To use this annotation, add a [data-test-id] HTML attribute to the element
+/// To use this annotation, add a 'data-test-id' HTML attribute to the element
 /// you wish to select. This assigns a test-only ID to the element so this
 /// annotation can target select that element.
 ///

--- a/test/data/html_setup.dart
+++ b/test/data/html_setup.dart
@@ -52,6 +52,7 @@ html.Element setUp() {
         <option id='option2' value='value 2' debug-id="option2">option 2</option>
         <option id='option3' value='value 3' debugId="option3">option 3</option>
       </select>
+      <div data-test-id="one">data-test-id</div>
       <textarea id='textarea'></textarea>
       <div id='keyboard-listener'>Listening:</div>
       <div class="outer-div">

--- a/test/data/webdriver_test_page.html
+++ b/test/data/webdriver_test_page.html
@@ -87,6 +87,7 @@ limitations under the License.
   <option id='option2' value='value 2' debug-id="option2">option 2</option>
   <option id='option3' value='value 3' debugId="option3">option 3</option>
 </select>
+<div data-test-id="one">data-test-id</div>
 <textarea id='textarea'></textarea>
 <div class="outer-div">
   outer div 1

--- a/test/src/annotations.dart
+++ b/test/src/annotations.dart
@@ -88,6 +88,11 @@ void runTests(GetNewContext contextGenerator) {
       expect(page.useDash.innerText, 'option 2');
       expect(page.useCamelCase.innerText, 'option 3');
     });
+    
+    test('TestId', () async {
+      final page = TestIds.create(contextGenerator());
+      expect(page.divOne.innerText, 'data-test-id');
+    });
   });
 
   group('custom annotations', () {
@@ -274,6 +279,16 @@ abstract class DebugIds {
 
   @ByDebugId('option3', useCamelCase: true)
   PageLoaderElement get useCamelCase;
+}
+
+@PageObject()
+abstract class TestIds {
+  TestIds();
+
+  factory TestIds.create(PageLoaderElement context) = $TestIds.create;
+
+  @ByTestId('one')
+  PageLoaderElement get divOne;
 }
 
 class PseudoByTagName implements CssFinder {


### PR DESCRIPTION
Create a `@ByTestId` annotation that selects element with attribute `data-test-id`.

Rationale behind this proposal:
Currently lots of test selectors are written using (layers of) css classes, tightly coupling tests to component styles and DOM structure, making them very brittle.
I'm working on a draft Testing on the Toilet episode that explains this problem in further detail. [go/change-resilient-ui-testing-tott](https://goto.google.com/change-resilient-ui-testing-tott)

Adding a `data-test-id` attribute to an element to help target-select it in tests is the solution we came to at Firebase console's design review. It allows a change-resilient way of writing selectors that survive any style changes or DOM restructuring. The original design doc is here: [go/change-resilient-ui-testing-dd](https://goto.google.com/change-resilient-ui-testing-dd)

This pattern has been adopted by some teams within google, also there are a few external articles covering this pattern:
https://kentcdodds.com/blog/making-your-ui-tests-resilient-to-change
https://medium.com/@colecodes/test-your-dom-with-data-attributes-44fccc43ed4b

To make selection of elements tagged with "data-test-id" easier, we are proposing this new annotation here.

I've already added this new annotation to Java's page loader library in [cl/253257572](https://critique.corp.google.com/#review/253257572). Would love Dart to have the same love!