### PR TITLE
Allow the latest build_config

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ environment:
 dependencies:
   analyzer: '>=0.35.0 <0.37.0'
   build: '>0.12.7 <2.0.0'
-  build_config: ^0.3.1
+  build_config: '>=0.3.1 <0.5.0'
   built_value: ^6.1.0
   matcher: ^0.12.0+1
   quiver: '>=2.0.0 <3.0.0'


### PR DESCRIPTION
The lower constraint ends up meaning that webdev latest doesn't work with this package.

Webdev latest requires build_runner 1.5.x but if you put that in your pubspec then you get errors like this from pub:

```
Resolving dependencies...
Because build_runner >=1.3.4 depends on build_config >=0.4.0 <0.4.1 and pageloader >=3.0.0 depends on build_config ^0.3.1, build_runner >=1.3.4 is incompatible with pageloader >=3.0.0.
So, because angular_tour_of_heroes depends on both build_runner ^1.5.0 and pageloader ^3.0.0, version solving failed.
```