### PR TITLE
remove direct dependency on package:build_config

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,6 @@ environment:
 dependencies:
   analyzer: '>=0.35.0 <0.37.0'
   build: '>0.12.7 <2.0.0'
-  build_config: ^0.3.1
   built_value: ^6.1.0
   matcher: ^0.12.0+1
   quiver: '>=2.0.0 <3.0.0'


### PR DESCRIPTION
package:build_config doesn't seem to be used directly by this package. This causes issues when packages using package:pageloader need to use a newer version of build_runner, for example:

```yaml
dependencies:
  build_runner: ^1.6.0
  pageloader: ^3.0.0
```

```
Because pageloader >=3.0.0 depends on build_config ^0.3.1 and build_runner >=1.3.4 depends on build_config >=0.4.0 <0.4.1, pageloader >=3.0.0 is incompatible with build_runner >=1.3.4.
```