### PR TITLE
Update to built_value ^7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.5
+
+- Use `built_value` version `7.0.0`.
+
 ## 3.2.4
 - Bump SDK minimum version to 2.3.
 

--- a/lib/src/generators/methods/core_method_information.g.dart
+++ b/lib/src/generators/methods/core_method_information.g.dart
@@ -12,7 +12,7 @@ class _$TypeInformation extends TypeInformation {
   @override
   final List<TypeInformation> typeArguments;
 
-  factory _$TypeInformation([void updates(TypeInformationBuilder b)]) =>
+  factory _$TypeInformation([void Function(TypeInformationBuilder) updates]) =>
       (new TypeInformationBuilder()..update(updates)).build();
 
   _$TypeInformation._({this.type, this.typeArguments}) : super._() {
@@ -25,7 +25,7 @@ class _$TypeInformation extends TypeInformation {
   }
 
   @override
-  TypeInformation rebuild(void updates(TypeInformationBuilder b)) =>
+  TypeInformation rebuild(void Function(TypeInformationBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -87,7 +87,7 @@ class TypeInformationBuilder
   }
 
   @override
-  void update(void updates(TypeInformationBuilder b)) {
+  void update(void Function(TypeInformationBuilder) updates) {
     if (updates != null) updates(this);
   }
 
@@ -133,7 +133,7 @@ class _$CoreMethodInformation extends CoreMethodInformation {
   final AstNode node;
 
   factory _$CoreMethodInformation(
-          [void updates(CoreMethodInformationBuilder b)]) =>
+          [void Function(CoreMethodInformationBuilder) updates]) =>
       (new CoreMethodInformationBuilder()..update(updates)).build();
 
   _$CoreMethodInformation._(
@@ -204,7 +204,8 @@ class _$CoreMethodInformation extends CoreMethodInformation {
   }
 
   @override
-  CoreMethodInformation rebuild(void updates(CoreMethodInformationBuilder b)) =>
+  CoreMethodInformation rebuild(
+          void Function(CoreMethodInformationBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -390,7 +391,7 @@ class CoreMethodInformationBuilder
   }
 
   @override
-  void update(void updates(CoreMethodInformationBuilder b)) {
+  void update(void Function(CoreMethodInformationBuilder) updates) {
     if (updates != null) updates(this);
   }
 
@@ -420,7 +421,7 @@ class CoreMethodInformationBuilder
 
 abstract class CoreMethodInformationBaseBuilder {
   void replace(CoreMethodInformationBase other);
-  void update(void updates(CoreMethodInformationBaseBuilder b));
+  void update(void Function(CoreMethodInformationBaseBuilder) updates);
   String get name;
   set name(String name);
 

--- a/lib/src/generators/methods/getter.g.dart
+++ b/lib/src/generators/methods/getter.g.dart
@@ -12,7 +12,7 @@ class _$Getter extends Getter {
   @override
   final String returnType;
 
-  factory _$Getter([void updates(GetterBuilder b)]) =>
+  factory _$Getter([void Function(GetterBuilder) updates]) =>
       (new GetterBuilder()..update(updates)).build();
 
   _$Getter._({this.name, this.returnType}) : super._() {
@@ -25,7 +25,7 @@ class _$Getter extends Getter {
   }
 
   @override
-  Getter rebuild(void updates(GetterBuilder b)) =>
+  Getter rebuild(void Function(GetterBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -84,7 +84,7 @@ class GetterBuilder implements Builder<Getter, GetterBuilder> {
   }
 
   @override
-  void update(void updates(GetterBuilder b)) {
+  void update(void Function(GetterBuilder) updates) {
     if (updates != null) updates(this);
   }
 

--- a/lib/src/generators/methods/iterable_finder_method.g.dart
+++ b/lib/src/generators/methods/iterable_finder_method.g.dart
@@ -19,7 +19,7 @@ class _$IterableFinderMethod extends IterableFinderMethod {
   final String checkerDeclarations;
 
   factory _$IterableFinderMethod(
-          [void updates(IterableFinderMethodBuilder b)]) =>
+          [void Function(IterableFinderMethodBuilder) updates]) =>
       (new IterableFinderMethodBuilder()..update(updates)).build();
 
   _$IterableFinderMethod._(
@@ -51,7 +51,8 @@ class _$IterableFinderMethod extends IterableFinderMethod {
   }
 
   @override
-  IterableFinderMethod rebuild(void updates(IterableFinderMethodBuilder b)) =>
+  IterableFinderMethod rebuild(
+          void Function(IterableFinderMethodBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -142,7 +143,7 @@ class IterableFinderMethodBuilder
   }
 
   @override
-  void update(void updates(IterableFinderMethodBuilder b)) {
+  void update(void Function(IterableFinderMethodBuilder) updates) {
     if (updates != null) updates(this);
   }
 

--- a/lib/src/generators/methods/list_finder_method.g.dart
+++ b/lib/src/generators/methods/list_finder_method.g.dart
@@ -22,7 +22,8 @@ class _$ListFinderMethod extends ListFinderMethod {
   @override
   final Optional<String> genericType;
 
-  factory _$ListFinderMethod([void updates(ListFinderMethodBuilder b)]) =>
+  factory _$ListFinderMethod(
+          [void Function(ListFinderMethodBuilder) updates]) =>
       (new ListFinderMethodBuilder()..update(updates)).build();
 
   _$ListFinderMethod._(
@@ -62,7 +63,7 @@ class _$ListFinderMethod extends ListFinderMethod {
   }
 
   @override
-  ListFinderMethod rebuild(void updates(ListFinderMethodBuilder b)) =>
+  ListFinderMethod rebuild(void Function(ListFinderMethodBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -174,7 +175,7 @@ class ListFinderMethodBuilder
   }
 
   @override
-  void update(void updates(ListFinderMethodBuilder b)) {
+  void update(void Function(ListFinderMethodBuilder) updates) {
     if (updates != null) updates(this);
   }
 
@@ -196,7 +197,7 @@ class ListFinderMethodBuilder
 
 abstract class ListFinderMethodBaseBuilder {
   void replace(ListFinderMethodBase other);
-  void update(void updates(ListFinderMethodBaseBuilder b));
+  void update(void Function(ListFinderMethodBaseBuilder) updates);
   String get name;
   set name(String name);
 

--- a/lib/src/generators/methods/mouse_finder_method.g.dart
+++ b/lib/src/generators/methods/mouse_finder_method.g.dart
@@ -10,7 +10,8 @@ class _$MouseFinderMethod extends MouseFinderMethod {
   @override
   final String name;
 
-  factory _$MouseFinderMethod([void updates(MouseFinderMethodBuilder b)]) =>
+  factory _$MouseFinderMethod(
+          [void Function(MouseFinderMethodBuilder) updates]) =>
       (new MouseFinderMethodBuilder()..update(updates)).build();
 
   _$MouseFinderMethod._({this.name}) : super._() {
@@ -20,7 +21,7 @@ class _$MouseFinderMethod extends MouseFinderMethod {
   }
 
   @override
-  MouseFinderMethod rebuild(void updates(MouseFinderMethodBuilder b)) =>
+  MouseFinderMethod rebuild(void Function(MouseFinderMethodBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -72,7 +73,7 @@ class MouseFinderMethodBuilder
   }
 
   @override
-  void update(void updates(MouseFinderMethodBuilder b)) {
+  void update(void Function(MouseFinderMethodBuilder) updates) {
     if (updates != null) updates(this);
   }
 

--- a/lib/src/generators/methods/setter.g.dart
+++ b/lib/src/generators/methods/setter.g.dart
@@ -14,7 +14,7 @@ class _$Setter extends Setter {
   @override
   final String setterValueName;
 
-  factory _$Setter([void updates(SetterBuilder b)]) =>
+  factory _$Setter([void Function(SetterBuilder) updates]) =>
       (new SetterBuilder()..update(updates)).build();
 
   _$Setter._({this.name, this.setterType, this.setterValueName}) : super._() {
@@ -30,7 +30,7 @@ class _$Setter extends Setter {
   }
 
   @override
-  Setter rebuild(void updates(SetterBuilder b)) =>
+  Setter rebuild(void Function(SetterBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -98,7 +98,7 @@ class SetterBuilder implements Builder<Setter, SetterBuilder> {
   }
 
   @override
-  void update(void updates(SetterBuilder b)) {
+  void update(void Function(SetterBuilder) updates) {
     if (updates != null) updates(this);
   }
 

--- a/lib/src/generators/methods/single_finder_method.g.dart
+++ b/lib/src/generators/methods/single_finder_method.g.dart
@@ -24,7 +24,8 @@ class _$SingleFinderMethod extends SingleFinderMethod {
   @override
   final bool isNullElement;
 
-  factory _$SingleFinderMethod([void updates(SingleFinderMethodBuilder b)]) =>
+  factory _$SingleFinderMethod(
+          [void Function(SingleFinderMethodBuilder) updates]) =>
       (new SingleFinderMethodBuilder()..update(updates)).build();
 
   _$SingleFinderMethod._(
@@ -68,7 +69,8 @@ class _$SingleFinderMethod extends SingleFinderMethod {
   }
 
   @override
-  SingleFinderMethod rebuild(void updates(SingleFinderMethodBuilder b)) =>
+  SingleFinderMethod rebuild(
+          void Function(SingleFinderMethodBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -190,7 +192,7 @@ class SingleFinderMethodBuilder
   }
 
   @override
-  void update(void updates(SingleFinderMethodBuilder b)) {
+  void update(void Function(SingleFinderMethodBuilder) updates) {
     if (updates != null) updates(this);
   }
 
@@ -213,7 +215,7 @@ class SingleFinderMethodBuilder
 
 abstract class SingleFinderMethodBaseBuilder {
   void replace(SingleFinderMethodBase other);
-  void update(void updates(SingleFinderMethodBaseBuilder b));
+  void update(void Function(SingleFinderMethodBaseBuilder) updates);
   String get name;
   set name(String name);
 

--- a/lib/src/generators/methods/unannotated_method.g.dart
+++ b/lib/src/generators/methods/unannotated_method.g.dart
@@ -16,7 +16,8 @@ class _$UnannotatedMethod extends UnannotatedMethod {
   @override
   final Optional<TypeParameterList> typeParameters;
 
-  factory _$UnannotatedMethod([void updates(UnannotatedMethodBuilder b)]) =>
+  factory _$UnannotatedMethod(
+          [void Function(UnannotatedMethodBuilder) updates]) =>
       (new UnannotatedMethodBuilder()..update(updates)).build();
 
   _$UnannotatedMethod._(
@@ -37,7 +38,7 @@ class _$UnannotatedMethod extends UnannotatedMethod {
   }
 
   @override
-  UnannotatedMethod rebuild(void updates(UnannotatedMethodBuilder b)) =>
+  UnannotatedMethod rebuild(void Function(UnannotatedMethodBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -117,7 +118,7 @@ class UnannotatedMethodBuilder
   }
 
   @override
-  void update(void updates(UnannotatedMethodBuilder b)) {
+  void update(void Function(UnannotatedMethodBuilder) updates) {
     if (updates != null) updates(this);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pageloader
 
-version: 3.2.4
+version: 3.2.5
 
 authors:
   - Marc Fisher II (emeritus) <fisherii@google.com>
@@ -19,7 +19,7 @@ environment:
 dependencies:
   analyzer: '>=0.36.0 <0.40.0'
   build: '>0.12.7 <2.0.0'
-  built_value: ^6.1.0
+  built_value: ^7.0.0
   build_config: '>=0.3.1 <5.0.0'
   matcher: ^0.12.0+1
   quiver: '>=2.0.0 <3.0.0'
@@ -28,6 +28,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.6.0
-  built_value_generator: ^6.2.0
+  built_value_generator: ^7.0.0
   path: ^1.3.6
   test: ^1.2.0

--- a/test/examples/correct/class_checks.g.dart
+++ b/test/examples/correct/class_checks.g.dart
@@ -7,8 +7,6 @@ part of 'class_checks.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $ClassChecks extends ClassChecks with $$ClassChecks {
   PageLoaderElement $__root__;
   $ClassChecks.create(PageLoaderElement currentContext)
@@ -17,12 +15,13 @@ class $ClassChecks extends ClassChecks with $$ClassChecks {
   }
   factory $ClassChecks.lookup(PageLoaderSource source) =>
       $ClassChecks.create(source.byTag('some-tag'));
-  static String get tagName => 'some-tag';
+  static const String tagName = 'some-tag';
+  String toStringDeep() => 'ClassChecks\n\n${$__root__.toStringDeep()}';
 }
 
 class $$ClassChecks {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get myRoot {
     for (final __listener in $__root__.listeners) {
@@ -37,6 +36,7 @@ class $$ClassChecks {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $EnsureTagChecks extends EnsureTagChecks with $$EnsureTagChecks {
   PageLoaderElement $__root__;
   $EnsureTagChecks.create(PageLoaderElement currentContext)
@@ -46,12 +46,13 @@ class $EnsureTagChecks extends EnsureTagChecks with $$EnsureTagChecks {
   }
   factory $EnsureTagChecks.lookup(PageLoaderSource source) =>
       $EnsureTagChecks.create(source.byTag('some-other-tag'));
-  static String get tagName => 'some-other-tag';
+  static const String tagName = 'some-other-tag';
+  String toStringDeep() => 'EnsureTagChecks\n\n${$__root__.toStringDeep()}';
 }
 
 class $$EnsureTagChecks {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get myRoot {
     for (final __listener in $__root__.listeners) {
@@ -66,6 +67,7 @@ class $$EnsureTagChecks {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $ClassChecksUsingMixin extends ClassChecksUsingMixin
     with $$ChecksMixin, $$ClassChecksUsingMixin {
   PageLoaderElement $__root__;
@@ -75,15 +77,18 @@ class $ClassChecksUsingMixin extends ClassChecksUsingMixin
   }
   factory $ClassChecksUsingMixin.lookup(PageLoaderSource source) =>
       $ClassChecksUsingMixin.create(source.byTag('some-tag'));
-  static String get tagName => 'some-tag';
+  static const String tagName = 'some-tag';
+  String toStringDeep() =>
+      'ClassChecksUsingMixin\n\n${$__root__.toStringDeep()}';
 }
 
 class $$ClassChecksUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $EnsureTagChecksUsingMixin extends EnsureTagChecksUsingMixin
     with $$ChecksMixin, $$EnsureTagChecksUsingMixin {
   PageLoaderElement $__root__;
@@ -94,18 +99,22 @@ class $EnsureTagChecksUsingMixin extends EnsureTagChecksUsingMixin
   }
   factory $EnsureTagChecksUsingMixin.lookup(PageLoaderSource source) =>
       $EnsureTagChecksUsingMixin.create(source.byTag('some-other-tag'));
-  static String get tagName => 'some-other-tag';
+  static const String tagName = 'some-other-tag';
+  String toStringDeep() =>
+      'EnsureTagChecksUsingMixin\n\n${$__root__.toStringDeep()}';
 }
 
 class $$EnsureTagChecksUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
+
 class $$ChecksMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get myRoot {
     for (final __listener in $__root__.listeners) {

--- a/test/examples/correct/empty.g.dart
+++ b/test/examples/correct/empty.g.dart
@@ -7,8 +7,6 @@ part of 'empty.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $Empty extends Empty with $$Empty {
   PageLoaderElement $__root__;
   $Empty.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -16,20 +14,23 @@ class $Empty extends Empty with $$Empty {
   }
   factory $Empty.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Empty is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Empty is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Empty". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'Empty\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Empty {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
+
 class $$EmptyMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }

--- a/test/examples/correct/finders.g.dart
+++ b/test/examples/correct/finders.g.dart
@@ -7,8 +7,6 @@ part of 'finders.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $Finders extends Finders with $$Finders {
   PageLoaderElement $__root__;
   $Finders.create(PageLoaderElement currentContext)
@@ -17,8 +15,8 @@ class $Finders extends Finders with $$Finders {
   }
   factory $Finders.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Finders is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Finders is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Finders". Requires @CheckTag annotation in order for "tagName" to be generated.';
   PageLoaderElement get secret {
@@ -31,11 +29,13 @@ class $Finders extends Finders with $$Finders {
     }
     return returnMe;
   }
+
+  String toStringDeep() => 'Finders\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Finders {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get _secret {
     for (final __listener in $__root__.listeners) {
@@ -87,6 +87,7 @@ class $$Finders {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $CheckTagPO extends CheckTagPO with $$CheckTagPO {
   PageLoaderElement $__root__;
   $CheckTagPO.create(PageLoaderElement currentContext)
@@ -95,7 +96,7 @@ class $CheckTagPO extends CheckTagPO with $$CheckTagPO {
   }
   factory $CheckTagPO.lookup(PageLoaderSource source) =>
       $CheckTagPO.create(source.byTag('check-tag-po'));
-  static String get tagName => 'check-tag-po';
+  static const String tagName = 'check-tag-po';
   String toString() {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('CheckTagPO', 'toString');
@@ -106,11 +107,13 @@ class $CheckTagPO extends CheckTagPO with $$CheckTagPO {
     }
     return returnMe;
   }
+
+  String toStringDeep() => 'CheckTagPO\n\n${$__root__.toStringDeep()}';
 }
 
 class $$CheckTagPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get _root {
     for (final __listener in $__root__.listeners) {
@@ -125,6 +128,7 @@ class $$CheckTagPO {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $FindersUsingMixin extends FindersUsingMixin
     with $$FindersMixin, $$FindersUsingMixin {
   PageLoaderElement $__root__;
@@ -134,21 +138,24 @@ class $FindersUsingMixin extends FindersUsingMixin
   }
   factory $FindersUsingMixin.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "FindersUsingMixin is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "FindersUsingMixin is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "FindersUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'FindersUsingMixin\n\n${$__root__.toStringDeep()}';
 }
 
 class $$FindersUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
+
 class $$FindersMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get _secret {
     for (final __listener in $__root__.listeners) {

--- a/test/examples/correct/generics.g.dart
+++ b/test/examples/correct/generics.g.dart
@@ -7,8 +7,6 @@ part of 'generics.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $Generics<T> extends Generics<T> with $$Generics<T> {
   PageLoaderElement $__root__;
   $Generics.create(PageLoaderElement currentContext)
@@ -17,8 +15,8 @@ class $Generics<T> extends Generics<T> with $$Generics<T> {
   }
   factory $Generics.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Generics is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Generics is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Generics". Requires @CheckTag annotation in order for "tagName" to be generated.';
   String typeDefParameter(T thing, MyGenericTypeDef<T> typeDef) {
@@ -32,24 +30,27 @@ class $Generics<T> extends Generics<T> with $$Generics<T> {
     return returnMe;
   }
 
-  T exampleMethod<T>(T v) {
+  S exampleMethod<S>(S s) {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Generics', 'exampleMethod');
     }
-    final returnMe = super.exampleMethod(v);
+    final returnMe = super.exampleMethod(s);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('Generics', 'exampleMethod');
     }
     return returnMe;
   }
+
+  String toStringDeep() => 'Generics\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Generics<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $CheckedGenerics<T> extends CheckedGenerics<T> with $$CheckedGenerics<T> {
   PageLoaderElement $__root__;
   $CheckedGenerics.create(PageLoaderElement currentContext)
@@ -58,7 +59,7 @@ class $CheckedGenerics<T> extends CheckedGenerics<T> with $$CheckedGenerics<T> {
   }
   factory $CheckedGenerics.lookup(PageLoaderSource source) =>
       $CheckedGenerics.create(source.byTag('checked-generics'));
-  static String get tagName => 'checked-generics';
+  static const String tagName = 'checked-generics';
   String typeDefParameter(T thing, MyGenericTypeDef<T> typeDef) {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('CheckedGenerics', 'typeDefParameter');
@@ -69,14 +70,17 @@ class $CheckedGenerics<T> extends CheckedGenerics<T> with $$CheckedGenerics<T> {
     }
     return returnMe;
   }
+
+  String toStringDeep() => 'CheckedGenerics\n\n${$__root__.toStringDeep()}';
 }
 
 class $$CheckedGenerics<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $GenericPair<T, V> extends GenericPair<T, V> with $$GenericPair<T, V> {
   PageLoaderElement $__root__;
   $GenericPair.create(PageLoaderElement currentContext)
@@ -85,28 +89,31 @@ class $GenericPair<T, V> extends GenericPair<T, V> with $$GenericPair<T, V> {
   }
   factory $GenericPair.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "GenericPair is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "GenericPair is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "GenericPair". Requires @CheckTag annotation in order for "tagName" to be generated.';
-  Map<T, V> exampleMethodMap<T, V>(T t, V v) {
+  Map<R, S> exampleMethodMap<R, S>(R r, S s) {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('GenericPair', 'exampleMethodMap');
     }
-    final returnMe = super.exampleMethodMap(t, v);
+    final returnMe = super.exampleMethodMap(r, s);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('GenericPair', 'exampleMethodMap');
     }
     return returnMe;
   }
+
+  String toStringDeep() => 'GenericPair\n\n${$__root__.toStringDeep()}';
 }
 
 class $$GenericPair<T, V> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $RootPo<T> extends RootPo<T> with $$RootPo<T> {
   PageLoaderElement $__root__;
   $RootPo.create(PageLoaderElement currentContext)
@@ -115,15 +122,16 @@ class $RootPo<T> extends RootPo<T> with $$RootPo<T> {
   }
   factory $RootPo.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "RootPo is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "RootPo is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "RootPo". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'RootPo\n\n${$__root__.toStringDeep()}';
 }
 
 class $$RootPo<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   Generics<T> get generics {
     for (final __listener in $__root__.listeners) {
@@ -177,6 +185,7 @@ class $$RootPo<T> {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $GenericsUsingMixin<T> extends GenericsUsingMixin<T>
     with $$GenericsMixin<T>, $$GenericsUsingMixin<T> {
   PageLoaderElement $__root__;
@@ -186,24 +195,28 @@ class $GenericsUsingMixin<T> extends GenericsUsingMixin<T>
   }
   factory $GenericsUsingMixin.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "GenericsUsingMixin is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "GenericsUsingMixin is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "GenericsUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'GenericsUsingMixin\n\n${$__root__.toStringDeep()}';
 }
 
 class $$GenericsUsingMixin<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
+
+// ignore_for_file: private_collision_in_mixin_application
 
 class $$GenericsMixin<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $GenericPairUsingMixin<T, V> extends GenericPairUsingMixin<T, V>
     with $$GenericPairMixin<T, V>, $$GenericPairUsingMixin<T, V> {
   PageLoaderElement $__root__;
@@ -213,24 +226,29 @@ class $GenericPairUsingMixin<T, V> extends GenericPairUsingMixin<T, V>
   }
   factory $GenericPairUsingMixin.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "GenericPairUsingMixin is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "GenericPairUsingMixin is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "GenericPairUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() =>
+      'GenericPairUsingMixin\n\n${$__root__.toStringDeep()}';
 }
 
 class $$GenericPairUsingMixin<T, V> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
+
+// ignore_for_file: private_collision_in_mixin_application
 
 class $$GenericPairMixin<T, V> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $RootPoUsingMixin<T> extends RootPoUsingMixin<T>
     with $$RootPoMixin<T>, $$RootPoUsingMixin<T> {
   PageLoaderElement $__root__;
@@ -240,21 +258,24 @@ class $RootPoUsingMixin<T> extends RootPoUsingMixin<T>
   }
   factory $RootPoUsingMixin.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "RootPoUsingMixin is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "RootPoUsingMixin is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "RootPoUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'RootPoUsingMixin\n\n${$__root__.toStringDeep()}';
 }
 
 class $$RootPoUsingMixin<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
+
 class $$RootPoMixin<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   Generics<T> get generics {
     for (final __listener in $__root__.listeners) {

--- a/test/examples/correct/iterables.g.dart
+++ b/test/examples/correct/iterables.g.dart
@@ -7,8 +7,6 @@ part of 'iterables.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $Iterables extends Iterables with $$Iterables {
   PageLoaderElement $__root__;
   $Iterables.create(PageLoaderElement currentContext)
@@ -17,15 +15,16 @@ class $Iterables extends Iterables with $$Iterables {
   }
   factory $Iterables.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Iterables is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Iterables is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Iterables". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'Iterables\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Iterables {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageObjectIterable<PageLoaderElement> get basics {
     for (final __listener in $__root__.listeners) {
@@ -67,6 +66,7 @@ class $$Iterables {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $InnerObject extends InnerObject with $$InnerObject {
   PageLoaderElement $__root__;
   $InnerObject.create(PageLoaderElement currentContext)
@@ -75,15 +75,16 @@ class $InnerObject extends InnerObject with $$InnerObject {
   }
   factory $InnerObject.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "InnerObject is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "InnerObject is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "InnerObject". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'InnerObject\n\n${$__root__.toStringDeep()}';
 }
 
 class $$InnerObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get single {
     for (final __listener in $__root__.listeners) {
@@ -124,6 +125,7 @@ class $$InnerObject {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $IterablesUsingMixin extends IterablesUsingMixin
     with $$IterablesMixin, $$IterablesUsingMixin {
   PageLoaderElement $__root__;
@@ -133,21 +135,24 @@ class $IterablesUsingMixin extends IterablesUsingMixin
   }
   factory $IterablesUsingMixin.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "IterablesUsingMixin is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "IterablesUsingMixin is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "IterablesUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'IterablesUsingMixin\n\n${$__root__.toStringDeep()}';
 }
 
 class $$IterablesUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
+
 class $$IterablesMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageObjectIterable<PageLoaderElement> get basics {
     for (final __listener in $__root__.listeners) {
@@ -189,6 +194,7 @@ class $$IterablesMixin {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $InnerObjectUsingMixin extends InnerObjectUsingMixin
     with $$InnerObjectMixin, $$InnerObjectUsingMixin {
   PageLoaderElement $__root__;
@@ -198,21 +204,25 @@ class $InnerObjectUsingMixin extends InnerObjectUsingMixin
   }
   factory $InnerObjectUsingMixin.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "InnerObjectUsingMixin is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "InnerObjectUsingMixin is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "InnerObjectUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() =>
+      'InnerObjectUsingMixin\n\n${$__root__.toStringDeep()}';
 }
 
 class $$InnerObjectUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
+
 class $$InnerObjectMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get single {
     for (final __listener in $__root__.listeners) {

--- a/test/examples/correct/list.g.dart
+++ b/test/examples/correct/list.g.dart
@@ -7,8 +7,6 @@ part of 'list.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $Lists extends Lists with $$Lists {
   PageLoaderElement $__root__;
   $Lists.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -16,15 +14,16 @@ class $Lists extends Lists with $$Lists {
   }
   factory $Lists.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Lists is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Lists is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Lists". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'Lists\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Lists {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   Future<PageObjectList<PageLoaderElement>> get basics async {
     for (final __listener in $__root__.listeners) {
@@ -105,6 +104,7 @@ class $$Lists {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $InnerListObject extends InnerListObject with $$InnerListObject {
   PageLoaderElement $__root__;
   $InnerListObject.create(PageLoaderElement currentContext)
@@ -113,15 +113,16 @@ class $InnerListObject extends InnerListObject with $$InnerListObject {
   }
   factory $InnerListObject.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "InnerListObject is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "InnerListObject is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "InnerListObject". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'InnerListObject\n\n${$__root__.toStringDeep()}';
 }
 
 class $$InnerListObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get single {
     for (final __listener in $__root__.listeners) {
@@ -149,6 +150,7 @@ class $$InnerListObject {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $ListsUsingMixin extends ListsUsingMixin
     with $$ListsMixin, $$ListsUsingMixin {
   PageLoaderElement $__root__;
@@ -158,21 +160,24 @@ class $ListsUsingMixin extends ListsUsingMixin
   }
   factory $ListsUsingMixin.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "ListsUsingMixin is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "ListsUsingMixin is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "ListsUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'ListsUsingMixin\n\n${$__root__.toStringDeep()}';
 }
 
 class $$ListsUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
+
 class $$ListsMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   Future<PageObjectList<PageLoaderElement>> get basics async {
     for (final __listener in $__root__.listeners) {
@@ -253,6 +258,7 @@ class $$ListsMixin {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $InnerListObjectUsingMixin extends InnerListObjectUsingMixin
     with $$InnerListObjectMixin, $$InnerListObjectUsingMixin {
   PageLoaderElement $__root__;
@@ -262,21 +268,25 @@ class $InnerListObjectUsingMixin extends InnerListObjectUsingMixin
   }
   factory $InnerListObjectUsingMixin.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "InnerListObjectUsingMixin is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "InnerListObjectUsingMixin is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "InnerListObjectUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() =>
+      'InnerListObjectUsingMixin\n\n${$__root__.toStringDeep()}';
 }
 
 class $$InnerListObjectUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
+
 class $$InnerListObjectMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get single {
     for (final __listener in $__root__.listeners) {

--- a/test/examples/correct/mouse.g.dart
+++ b/test/examples/correct/mouse.g.dart
@@ -7,8 +7,6 @@ part of 'mouse.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $MouseObject extends MouseObject with $$MouseObject {
   PageLoaderElement $__root__;
   $MouseObject.create(PageLoaderElement currentContext)
@@ -17,15 +15,16 @@ class $MouseObject extends MouseObject with $$MouseObject {
   }
   factory $MouseObject.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "MouseObject is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "MouseObject is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "MouseObject". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'MouseObject\n\n${$__root__.toStringDeep()}';
 }
 
 class $$MouseObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderMouse get mouse {
     for (final __listener in $__root__.listeners) {
@@ -40,6 +39,7 @@ class $$MouseObject {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $MouseObjectUsingMixin extends MouseObjectUsingMixin
     with $$MouseObjectMixin, $$MouseObjectUsingMixin {
   PageLoaderElement $__root__;
@@ -49,21 +49,25 @@ class $MouseObjectUsingMixin extends MouseObjectUsingMixin
   }
   factory $MouseObjectUsingMixin.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "MouseObjectUsingMixin is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "MouseObjectUsingMixin is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "MouseObjectUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() =>
+      'MouseObjectUsingMixin\n\n${$__root__.toStringDeep()}';
 }
 
 class $$MouseObjectUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
+
 class $$MouseObjectMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderMouse get mouse {
     for (final __listener in $__root__.listeners) {

--- a/test/examples/correct/multiple_in_file.g.dart
+++ b/test/examples/correct/multiple_in_file.g.dart
@@ -7,8 +7,6 @@ part of 'multiple_in_file.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $A extends A with $$A {
   PageLoaderElement $__root__;
   $A.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -16,15 +14,16 @@ class $A extends A with $$A {
   }
   factory $A.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "A is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "A is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "A". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'A\n\n${$__root__.toStringDeep()}';
 }
 
 class $$A {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   B get b {
     for (final __listener in $__root__.listeners) {
@@ -39,6 +38,7 @@ class $$A {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $B extends B with $$B {
   PageLoaderElement $__root__;
   $B.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -46,15 +46,16 @@ class $B extends B with $$B {
   }
   factory $B.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "B is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "B is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "B". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'B\n\n${$__root__.toStringDeep()}';
 }
 
 class $$B {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get base {
     for (final __listener in $__root__.listeners) {
@@ -69,6 +70,7 @@ class $$B {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $C extends C with $$C {
   PageLoaderElement $__root__;
   $C.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -76,15 +78,16 @@ class $C extends C with $$C {
   }
   factory $C.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "C is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "C is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "C". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'C\n\n${$__root__.toStringDeep()}';
 }
 
 class $$C {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   B get b {
     for (final __listener in $__root__.listeners) {

--- a/test/examples/correct/nested.g.dart
+++ b/test/examples/correct/nested.g.dart
@@ -7,8 +7,6 @@ part of 'nested.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $Nested extends Nested with $$Nested {
   PageLoaderElement $__root__;
   $Nested.create(PageLoaderElement currentContext)
@@ -17,15 +15,16 @@ class $Nested extends Nested with $$Nested {
   }
   factory $Nested.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Nested is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Nested is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Nested". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'Nested\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Nested {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   Finders get findersElement {
     for (final __listener in $__root__.listeners) {
@@ -40,6 +39,7 @@ class $$Nested {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $NestedUsingMixin extends NestedUsingMixin
     with $$NestedMixin, $$NestedUsingMixin {
   PageLoaderElement $__root__;
@@ -49,21 +49,24 @@ class $NestedUsingMixin extends NestedUsingMixin
   }
   factory $NestedUsingMixin.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "NestedUsingMixin is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "NestedUsingMixin is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "NestedUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'NestedUsingMixin\n\n${$__root__.toStringDeep()}';
 }
 
 class $$NestedUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
+
 class $$NestedMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   FindersUsingMixin get findersElement {
     for (final __listener in $__root__.listeners) {

--- a/test/examples/correct/null_element.g.dart
+++ b/test/examples/correct/null_element.g.dart
@@ -15,8 +15,8 @@ class $ParentRoot extends ParentRoot with $$ParentRoot {
   }
   factory $ParentRoot.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "ParentRoot is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "ParentRoot is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "ParentRoot". Requires @CheckTag annotation in order for "tagName" to be generated.';
   String toStringDeep() => 'ParentRoot\n\n${$__root__.toStringDeep()}';
@@ -25,9 +25,7 @@ class $ParentRoot extends ParentRoot with $$ParentRoot {
 class $$ParentRoot {
   PageLoaderElement $__root__;
   PageLoaderMouse __mouse__;
-
   PageLoaderElement get $root => $__root__;
-
   PageLoaderElement get _nullElement {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('ParentRoot', '_nullElement');
@@ -61,6 +59,7 @@ class $$ParentRoot {
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('ParentRoot', 'gens');
     }
+    return returnMe;
   }
 }
 
@@ -73,8 +72,8 @@ class $NullPO extends NullPO with $$NullPO {
   }
   factory $NullPO.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "NullPO is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "NullPO is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "NullPO". Requires @CheckTag annotation in order for "tagName" to be generated.';
   String toStringDeep() => 'NullPO\n\n${$__root__.toStringDeep()}';
@@ -95,8 +94,8 @@ class $Generics<T> extends Generics<T> with $$Generics<T> {
   }
   factory $Generics.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Generics is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Generics is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Generics". Requires @CheckTag annotation in order for "tagName" to be generated.';
   String toStringDeep() => 'Generics\n\n${$__root__.toStringDeep()}';

--- a/test/examples/correct/parameters.g.dart
+++ b/test/examples/correct/parameters.g.dart
@@ -7,8 +7,6 @@ part of 'parameters.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $Parameters extends Parameters with $$Parameters {
   PageLoaderElement $__root__;
   $Parameters.create(PageLoaderElement currentContext)
@@ -17,8 +15,8 @@ class $Parameters extends Parameters with $$Parameters {
   }
   factory $Parameters.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Parameters is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Parameters is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Parameters". Requires @CheckTag annotation in order for "tagName" to be generated.';
   String testOptionalPositionalParam(
@@ -49,7 +47,7 @@ class $Parameters extends Parameters with $$Parameters {
     return returnMe;
   }
 
-  String testOptionalNamedParam({String first: 'a', String second: 'b'}) {
+  String testOptionalNamedParam({String first = 'a', String second = 'b'}) {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Parameters', 'testOptionalNamedParam');
     }
@@ -61,7 +59,7 @@ class $Parameters extends Parameters with $$Parameters {
   }
 
   String testMixedOptionalNamedParam(String x,
-      {String first: 'a', String second: 'b'}) {
+      {String first = 'a', String second = 'b'}) {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod(
           'Parameters', 'testMixedOptionalNamedParam');
@@ -74,14 +72,17 @@ class $Parameters extends Parameters with $$Parameters {
     }
     return returnMe;
   }
+
+  String toStringDeep() => 'Parameters\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Parameters {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $ParametersUsingMixin extends ParametersUsingMixin
     with $$ParametersMixin, $$ParametersUsingMixin {
   PageLoaderElement $__root__;
@@ -91,20 +92,24 @@ class $ParametersUsingMixin extends ParametersUsingMixin
   }
   factory $ParametersUsingMixin.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "ParametersUsingMixin is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "ParametersUsingMixin is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "ParametersUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() =>
+      'ParametersUsingMixin\n\n${$__root__.toStringDeep()}';
 }
 
 class $$ParametersUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
+
 class $$ParametersMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }

--- a/test/examples/correct/root.g.dart
+++ b/test/examples/correct/root.g.dart
@@ -7,8 +7,6 @@ part of 'root.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $ParentRoot extends ParentRoot with $$ParentRoot {
   PageLoaderElement $__root__;
   $ParentRoot.create(PageLoaderElement currentContext)
@@ -17,15 +15,16 @@ class $ParentRoot extends ParentRoot with $$ParentRoot {
   }
   factory $ParentRoot.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "ParentRoot is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "ParentRoot is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "ParentRoot". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'ParentRoot\n\n${$__root__.toStringDeep()}';
 }
 
 class $$ParentRoot {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   Root get root {
     for (final __listener in $__root__.listeners) {
@@ -40,6 +39,7 @@ class $$ParentRoot {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $Root extends Root with $$Root {
   PageLoaderElement $__root__;
   $Root.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -47,15 +47,16 @@ class $Root extends Root with $$Root {
   }
   factory $Root.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Root is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Root is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Root". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'Root\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Root {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get myRoot {
     for (final __listener in $__root__.listeners) {
@@ -82,6 +83,7 @@ class $$Root {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $ParentRootUsingMixin extends ParentRootUsingMixin
     with $$ParentRootMixin, $$ParentRootUsingMixin {
   PageLoaderElement $__root__;
@@ -91,21 +93,25 @@ class $ParentRootUsingMixin extends ParentRootUsingMixin
   }
   factory $ParentRootUsingMixin.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "ParentRootUsingMixin is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "ParentRootUsingMixin is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "ParentRootUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() =>
+      'ParentRootUsingMixin\n\n${$__root__.toStringDeep()}';
 }
 
 class $$ParentRootUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
+
 class $$ParentRootMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   RootUsingMixin get root {
     for (final __listener in $__root__.listeners) {
@@ -120,6 +126,7 @@ class $$ParentRootMixin {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $RootUsingMixin extends RootUsingMixin
     with $$RootMixin, $$RootUsingMixin {
   PageLoaderElement $__root__;
@@ -129,21 +136,24 @@ class $RootUsingMixin extends RootUsingMixin
   }
   factory $RootUsingMixin.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "RootUsingMixin is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "RootUsingMixin is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "RootUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'RootUsingMixin\n\n${$__root__.toStringDeep()}';
 }
 
 class $$RootUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
+
 class $$RootMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get myRoot {
     for (final __listener in $__root__.listeners) {

--- a/test/examples/correct/unannotated.g.dart
+++ b/test/examples/correct/unannotated.g.dart
@@ -7,8 +7,6 @@ part of 'unannotated.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $Unannotated extends Unannotated with $$Unannotated {
   PageLoaderElement $__root__;
   $Unannotated.create(PageLoaderElement currentContext)
@@ -17,8 +15,8 @@ class $Unannotated extends Unannotated with $$Unannotated {
   }
   factory $Unannotated.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Unannotated is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Unannotated is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Unannotated". Requires @CheckTag annotation in order for "tagName" to be generated.';
   bool get isFieldSet {
@@ -108,14 +106,17 @@ class $Unannotated extends Unannotated with $$Unannotated {
     }
     return;
   }
+
+  String toStringDeep() => 'Unannotated\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Unannotated {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $UnannotatedUsingMixin extends UnannotatedUsingMixin
     with $$UnannotatedMixin, $$UnannotatedUsingMixin {
   PageLoaderElement $__root__;
@@ -125,20 +126,24 @@ class $UnannotatedUsingMixin extends UnannotatedUsingMixin
   }
   factory $UnannotatedUsingMixin.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "UnannotatedUsingMixin is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "UnannotatedUsingMixin is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "UnannotatedUsingMixin". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() =>
+      'UnannotatedUsingMixin\n\n${$__root__.toStringDeep()}';
 }
 
 class $$UnannotatedUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
+
 class $$UnannotatedMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }

--- a/test/src/annotations.g.dart
+++ b/test/src/annotations.g.dart
@@ -7,8 +7,6 @@ part of 'annotations.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $BaseObject extends BaseObject with $$BaseObject {
   PageLoaderElement $__root__;
   $BaseObject.create(PageLoaderElement currentContext)
@@ -17,15 +15,16 @@ class $BaseObject extends BaseObject with $$BaseObject {
   }
   factory $BaseObject.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "BaseObject is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "BaseObject is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "BaseObject". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'BaseObject\n\n${$__root__.toStringDeep()}';
 }
 
 class $$BaseObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   TableForCheckTag get table {
     for (final __listener in $__root__.listeners) {
@@ -76,6 +75,7 @@ class $$BaseObject {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $PseudoBaseObject extends PseudoBaseObject with $$PseudoBaseObject {
   PageLoaderElement $__root__;
   $PseudoBaseObject.create(PageLoaderElement currentContext)
@@ -84,15 +84,16 @@ class $PseudoBaseObject extends PseudoBaseObject with $$PseudoBaseObject {
   }
   factory $PseudoBaseObject.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PseudoBaseObject is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PseudoBaseObject is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PseudoBaseObject". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'PseudoBaseObject\n\n${$__root__.toStringDeep()}';
 }
 
 class $$PseudoBaseObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   TableForCheckTag get table {
     for (final __listener in $__root__.listeners) {
@@ -132,6 +133,7 @@ class $$PseudoBaseObject {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $TableForCheckTag extends TableForCheckTag with $$TableForCheckTag {
   PageLoaderElement $__root__;
   $TableForCheckTag.create(PageLoaderElement currentContext)
@@ -140,12 +142,13 @@ class $TableForCheckTag extends TableForCheckTag with $$TableForCheckTag {
   }
   factory $TableForCheckTag.lookup(PageLoaderSource source) =>
       $TableForCheckTag.create(source.byTag('table'));
-  static String get tagName => 'table';
+  static const String tagName = 'table';
+  String toStringDeep() => 'TableForCheckTag\n\n${$__root__.toStringDeep()}';
 }
 
 class $$TableForCheckTag {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get table {
     for (final __listener in $__root__.listeners) {
@@ -185,6 +188,7 @@ class $$TableForCheckTag {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $BaseEnsureObject extends BaseEnsureObject with $$BaseEnsureObject {
   PageLoaderElement $__root__;
   $BaseEnsureObject.create(PageLoaderElement currentContext)
@@ -193,15 +197,16 @@ class $BaseEnsureObject extends BaseEnsureObject with $$BaseEnsureObject {
   }
   factory $BaseEnsureObject.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "BaseEnsureObject is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "BaseEnsureObject is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "BaseEnsureObject". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'BaseEnsureObject\n\n${$__root__.toStringDeep()}';
 }
 
 class $$BaseEnsureObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   TableForEnsureTag get table {
     for (final __listener in $__root__.listeners) {
@@ -228,6 +233,7 @@ class $$BaseEnsureObject {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $TableForEnsureTag extends TableForEnsureTag with $$TableForEnsureTag {
   PageLoaderElement $__root__;
   $TableForEnsureTag.create(PageLoaderElement currentContext)
@@ -236,12 +242,13 @@ class $TableForEnsureTag extends TableForEnsureTag with $$TableForEnsureTag {
   }
   factory $TableForEnsureTag.lookup(PageLoaderSource source) =>
       $TableForEnsureTag.create(source.byTag('table'));
-  static String get tagName => 'table';
+  static const String tagName = 'table';
+  String toStringDeep() => 'TableForEnsureTag\n\n${$__root__.toStringDeep()}';
 }
 
 class $$TableForEnsureTag {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get table {
     for (final __listener in $__root__.listeners) {
@@ -269,6 +276,7 @@ class $$TableForEnsureTag {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $CheckTagFails extends CheckTagFails with $$CheckTagFails {
   PageLoaderElement $__root__;
   $CheckTagFails.create(PageLoaderElement currentContext)
@@ -277,12 +285,13 @@ class $CheckTagFails extends CheckTagFails with $$CheckTagFails {
   }
   factory $CheckTagFails.lookup(PageLoaderSource source) =>
       $CheckTagFails.create(source.byTag('inconceivable'));
-  static String get tagName => 'inconceivable';
+  static const String tagName = 'inconceivable';
+  String toStringDeep() => 'CheckTagFails\n\n${$__root__.toStringDeep()}';
 }
 
 class $$CheckTagFails {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get table {
     for (final __listener in $__root__.listeners) {
@@ -297,6 +306,7 @@ class $$CheckTagFails {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $EnsureTagFails extends EnsureTagFails with $$EnsureTagFails {
   PageLoaderElement $__root__;
   $EnsureTagFails.create(PageLoaderElement currentContext)
@@ -306,12 +316,13 @@ class $EnsureTagFails extends EnsureTagFails with $$EnsureTagFails {
   }
   factory $EnsureTagFails.lookup(PageLoaderSource source) =>
       $EnsureTagFails.create(source.byTag('inconceivable'));
-  static String get tagName => 'inconceivable';
+  static const String tagName = 'inconceivable';
+  String toStringDeep() => 'EnsureTagFails\n\n${$__root__.toStringDeep()}';
 }
 
 class $$EnsureTagFails {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get table {
     for (final __listener in $__root__.listeners) {
@@ -326,6 +337,7 @@ class $$EnsureTagFails {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $PageForWithAttributeTest extends PageForWithAttributeTest
     with $$PageForWithAttributeTest {
   PageLoaderElement $__root__;
@@ -335,15 +347,17 @@ class $PageForWithAttributeTest extends PageForWithAttributeTest
   }
   factory $PageForWithAttributeTest.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PageForWithAttributeTest is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PageForWithAttributeTest is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PageForWithAttributeTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() =>
+      'PageForWithAttributeTest\n\n${$__root__.toStringDeep()}';
 }
 
 class $$PageForWithAttributeTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get element {
     for (final __listener in $__root__.listeners) {
@@ -359,6 +373,7 @@ class $$PageForWithAttributeTest {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $PageForWithClassTest extends PageForWithClassTest
     with $$PageForWithClassTest {
   PageLoaderElement $__root__;
@@ -368,15 +383,17 @@ class $PageForWithClassTest extends PageForWithClassTest
   }
   factory $PageForWithClassTest.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PageForWithClassTest is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PageForWithClassTest is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PageForWithClassTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() =>
+      'PageForWithClassTest\n\n${$__root__.toStringDeep()}';
 }
 
 class $$PageForWithClassTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get element {
     for (final __listener in $__root__.listeners) {
@@ -392,6 +409,7 @@ class $$PageForWithClassTest {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $DebugIds extends DebugIds with $$DebugIds {
   PageLoaderElement $__root__;
   $DebugIds.create(PageLoaderElement currentContext)
@@ -400,15 +418,16 @@ class $DebugIds extends DebugIds with $$DebugIds {
   }
   factory $DebugIds.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "DebugIds is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "DebugIds is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "DebugIds". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'DebugIds\n\n${$__root__.toStringDeep()}';
 }
 
 class $$DebugIds {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get option1 {
     for (final __listener in $__root__.listeners) {
@@ -481,6 +500,39 @@ class $$DebugIds {
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('DebugIds', 'useCamelCase');
+    }
+    return returnMe;
+  }
+}
+
+// ignore_for_file: private_collision_in_mixin_application
+class $TestIds extends TestIds with $$TestIds {
+  PageLoaderElement $__root__;
+  $TestIds.create(PageLoaderElement currentContext)
+      : $__root__ = currentContext {
+    $__root__.addCheckers([]);
+  }
+  factory $TestIds.lookup(PageLoaderSource source) =>
+      throw "'lookup' constructor for class "
+          "TestIds is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
+  static String get tagName =>
+      throw '"tagName" is not defined by Page Object "TestIds". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'TestIds\n\n${$__root__.toStringDeep()}';
+}
+
+class $$TestIds {
+  PageLoaderElement $__root__;
+  PageLoaderMouse __mouse__;
+  PageLoaderElement get $root => $__root__;
+  PageLoaderElement get divOne {
+    for (final __listener in $__root__.listeners) {
+      __listener.startPageObjectMethod('TestIds', 'divOne');
+    }
+    final element = $__root__.createElement(ByTestId('one'), [], []);
+    final returnMe = element;
+    for (final __listener in $__root__.listeners) {
+      __listener.endPageObjectMethod('TestIds', 'divOne');
     }
     return returnMe;
   }

--- a/test/src/attributes.g.dart
+++ b/test/src/attributes.g.dart
@@ -7,8 +7,6 @@ part of 'attributes.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $PageForAttributesTests extends PageForAttributesTests
     with $$PageForAttributesTests {
   PageLoaderElement $__root__;
@@ -18,15 +16,17 @@ class $PageForAttributesTests extends PageForAttributesTests
   }
   factory $PageForAttributesTests.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PageForAttributesTests is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PageForAttributesTests is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PageForAttributesTests". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() =>
+      'PageForAttributesTests\n\n${$__root__.toStringDeep()}';
 }
 
 class $$PageForAttributesTests {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get divWithStyle {
     for (final __listener in $__root__.listeners) {

--- a/test/src/basic.g.dart
+++ b/test/src/basic.g.dart
@@ -7,8 +7,6 @@ part of 'basic.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $PageForExistsTest extends PageForExistsTest with $$PageForExistsTest {
   PageLoaderElement $__root__;
   $PageForExistsTest.create(PageLoaderElement currentContext)
@@ -17,15 +15,16 @@ class $PageForExistsTest extends PageForExistsTest with $$PageForExistsTest {
   }
   factory $PageForExistsTest.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PageForExistsTest is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PageForExistsTest is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PageForExistsTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'PageForExistsTest\n\n${$__root__.toStringDeep()}';
 }
 
 class $$PageForExistsTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get doesntExist {
     for (final __listener in $__root__.listeners) {
@@ -64,6 +63,7 @@ class $$PageForExistsTest {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $PageForVisibilityTest extends PageForVisibilityTest
     with $$PageForVisibilityTest {
   PageLoaderElement $__root__;
@@ -73,15 +73,17 @@ class $PageForVisibilityTest extends PageForVisibilityTest
   }
   factory $PageForVisibilityTest.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PageForVisibilityTest is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PageForVisibilityTest is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PageForVisibilityTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() =>
+      'PageForVisibilityTest\n\n${$__root__.toStringDeep()}';
 }
 
 class $$PageForVisibilityTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get invisibleDiv {
     for (final __listener in $__root__.listeners) {
@@ -109,6 +111,7 @@ class $$PageForVisibilityTest {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $PageForClassAnnotationTest extends PageForClassAnnotationTest
     with $$PageForClassAnnotationTest {
   PageLoaderElement $__root__;
@@ -118,15 +121,17 @@ class $PageForClassAnnotationTest extends PageForClassAnnotationTest
   }
   factory $PageForClassAnnotationTest.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PageForClassAnnotationTest is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PageForClassAnnotationTest is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PageForClassAnnotationTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() =>
+      'PageForClassAnnotationTest\n\n${$__root__.toStringDeep()}';
 }
 
 class $$PageForClassAnnotationTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   Table get table {
     for (final __listener in $__root__.listeners) {
@@ -141,6 +146,7 @@ class $$PageForClassAnnotationTest {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $PageForPrivateFieldsTest extends PageForPrivateFieldsTest
     with $$PageForPrivateFieldsTest {
   PageLoaderElement $__root__;
@@ -150,8 +156,8 @@ class $PageForPrivateFieldsTest extends PageForPrivateFieldsTest
   }
   factory $PageForPrivateFieldsTest.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PageForPrivateFieldsTest is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PageForPrivateFieldsTest is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PageForPrivateFieldsTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
   Table get table {
@@ -164,11 +170,14 @@ class $PageForPrivateFieldsTest extends PageForPrivateFieldsTest
     }
     return returnMe;
   }
+
+  String toStringDeep() =>
+      'PageForPrivateFieldsTest\n\n${$__root__.toStringDeep()}';
 }
 
 class $$PageForPrivateFieldsTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   Table get _privateTable {
     for (final __listener in $__root__.listeners) {
@@ -185,6 +194,7 @@ class $$PageForPrivateFieldsTest {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $PageForFocusTest extends PageForFocusTest with $$PageForFocusTest {
   PageLoaderElement $__root__;
   $PageForFocusTest.create(PageLoaderElement currentContext)
@@ -193,15 +203,16 @@ class $PageForFocusTest extends PageForFocusTest with $$PageForFocusTest {
   }
   factory $PageForFocusTest.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PageForFocusTest is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PageForFocusTest is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PageForFocusTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'PageForFocusTest\n\n${$__root__.toStringDeep()}';
 }
 
 class $$PageForFocusTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get textfield {
     for (final __listener in $__root__.listeners) {
@@ -216,6 +227,7 @@ class $$PageForFocusTest {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $PageForNbspTest extends PageForNbspTest with $$PageForNbspTest {
   PageLoaderElement $__root__;
   $PageForNbspTest.create(PageLoaderElement currentContext)
@@ -224,15 +236,16 @@ class $PageForNbspTest extends PageForNbspTest with $$PageForNbspTest {
   }
   factory $PageForNbspTest.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PageForNbspTest is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PageForNbspTest is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PageForNbspTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'PageForNbspTest\n\n${$__root__.toStringDeep()}';
 }
 
 class $$PageForNbspTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get span {
     for (final __listener in $__root__.listeners) {
@@ -247,6 +260,7 @@ class $$PageForNbspTest {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $Basic extends Basic with $$Basic {
   PageLoaderElement $__root__;
   $Basic.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -254,15 +268,16 @@ class $Basic extends Basic with $$Basic {
   }
   factory $Basic.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Basic is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Basic is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Basic". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'Basic\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Basic {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   OuterNested get outerNested {
     for (final __listener in $__root__.listeners) {
@@ -277,6 +292,7 @@ class $$Basic {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $OuterNested extends OuterNested with $$OuterNested {
   PageLoaderElement $__root__;
   $OuterNested.create(PageLoaderElement currentContext)
@@ -285,15 +301,16 @@ class $OuterNested extends OuterNested with $$OuterNested {
   }
   factory $OuterNested.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "OuterNested is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "OuterNested is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "OuterNested". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'OuterNested\n\n${$__root__.toStringDeep()}';
 }
 
 class $$OuterNested {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get innerNested {
     for (final __listener in $__root__.listeners) {
@@ -308,6 +325,7 @@ class $$OuterNested {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $DebugId extends DebugId with $$DebugId {
   PageLoaderElement $__root__;
   $DebugId.create(PageLoaderElement currentContext)
@@ -316,15 +334,16 @@ class $DebugId extends DebugId with $$DebugId {
   }
   factory $DebugId.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "DebugId is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "DebugId is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "DebugId". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'DebugId\n\n${$__root__.toStringDeep()}';
 }
 
 class $$DebugId {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get debug {
     for (final __listener in $__root__.listeners) {
@@ -339,6 +358,7 @@ class $$DebugId {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $Display extends Display with $$Display {
   PageLoaderElement $__root__;
   $Display.create(PageLoaderElement currentContext)
@@ -347,15 +367,16 @@ class $Display extends Display with $$Display {
   }
   factory $Display.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Display is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Display is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Display". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'Display\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Display {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get notDisplayed {
     for (final __listener in $__root__.listeners) {

--- a/test/src/cache_invalidation.g.dart
+++ b/test/src/cache_invalidation.g.dart
@@ -7,8 +7,6 @@ part of 'cache_invalidation.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $CacheInvalidation extends CacheInvalidation with $$CacheInvalidation {
   PageLoaderElement $__root__;
   $CacheInvalidation.create(PageLoaderElement currentContext)
@@ -17,15 +15,16 @@ class $CacheInvalidation extends CacheInvalidation with $$CacheInvalidation {
   }
   factory $CacheInvalidation.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "CacheInvalidation is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "CacheInvalidation is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "CacheInvalidation". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'CacheInvalidation\n\n${$__root__.toStringDeep()}';
 }
 
 class $$CacheInvalidation {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get button1 {
     for (final __listener in $__root__.listeners) {
@@ -52,6 +51,7 @@ class $$CacheInvalidation {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $_Nested extends _Nested with $$_Nested {
   PageLoaderElement $__root__;
   $_Nested.create(PageLoaderElement currentContext)
@@ -60,15 +60,16 @@ class $_Nested extends _Nested with $$_Nested {
   }
   factory $_Nested.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "_Nested is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "_Nested is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "_Nested". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => '_Nested\n\n${$__root__.toStringDeep()}';
 }
 
 class $$_Nested {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get option1 {
     for (final __listener in $__root__.listeners) {

--- a/test/src/constructors.g.dart
+++ b/test/src/constructors.g.dart
@@ -7,8 +7,6 @@ part of 'constructors.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $BasePO extends BasePO with $$BasePO {
   PageLoaderElement $__root__;
   $BasePO.create(PageLoaderElement currentContext)
@@ -17,15 +15,16 @@ class $BasePO extends BasePO with $$BasePO {
   }
   factory $BasePO.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "BasePO is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "BasePO is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "BasePO". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'BasePO\n\n${$__root__.toStringDeep()}';
 }
 
 class $$BasePO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   BCustomTagPO get bTagPO {
     for (final __listener in $__root__.listeners) {
@@ -41,6 +40,7 @@ class $$BasePO {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $BCustomTagPO extends BCustomTagPO with $$BCustomTagPO {
   PageLoaderElement $__root__;
   $BCustomTagPO.create(PageLoaderElement currentContext)
@@ -49,7 +49,7 @@ class $BCustomTagPO extends BCustomTagPO with $$BCustomTagPO {
   }
   factory $BCustomTagPO.lookup(PageLoaderSource source) =>
       $BCustomTagPO.create(source.byTag(BCustomTagPO.tagName));
-  static String get tagName => BCustomTagPO.tagName;
+  static const String tagName = BCustomTagPO.tagName;
   PageLoaderElement get rootElement {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('BCustomTagPO', 'rootElement');
@@ -104,11 +104,13 @@ class $BCustomTagPO extends BCustomTagPO with $$BCustomTagPO {
     }
     return returnMe;
   }
+
+  String toStringDeep() => 'BCustomTagPO\n\n${$__root__.toStringDeep()}';
 }
 
 class $$BCustomTagPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get _root {
     for (final __listener in $__root__.listeners) {
@@ -123,6 +125,7 @@ class $$BCustomTagPO {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $CCustomTagPO extends CCustomTagPO with $$CCustomTagPO {
   PageLoaderElement $__root__;
   $CCustomTagPO.create(PageLoaderElement currentContext)
@@ -131,7 +134,7 @@ class $CCustomTagPO extends CCustomTagPO with $$CCustomTagPO {
   }
   factory $CCustomTagPO.lookup(PageLoaderSource source) =>
       $CCustomTagPO.create(source.byTag(CCustomTagPO.tagName));
-  static String get tagName => CCustomTagPO.tagName;
+  static const String tagName = CCustomTagPO.tagName;
   String get innerText {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('CCustomTagPO', 'innerText');
@@ -142,11 +145,13 @@ class $CCustomTagPO extends CCustomTagPO with $$CCustomTagPO {
     }
     return returnMe;
   }
+
+  String toStringDeep() => 'CCustomTagPO\n\n${$__root__.toStringDeep()}';
 }
 
 class $$CCustomTagPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get _root {
     for (final __listener in $__root__.listeners) {
@@ -161,6 +166,7 @@ class $$CCustomTagPO {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $NoLookupPO extends NoLookupPO with $$NoLookupPO {
   PageLoaderElement $__root__;
   $NoLookupPO.create(PageLoaderElement currentContext)
@@ -169,14 +175,15 @@ class $NoLookupPO extends NoLookupPO with $$NoLookupPO {
   }
   factory $NoLookupPO.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "NoLookupPO is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "NoLookupPO is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "NoLookupPO". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'NoLookupPO\n\n${$__root__.toStringDeep()}';
 }
 
 class $$NoLookupPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }

--- a/test/src/generics.g.dart
+++ b/test/src/generics.g.dart
@@ -7,8 +7,6 @@ part of 'generics.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $Generics<T> extends Generics<T> with $$Generics<T> {
   PageLoaderElement $__root__;
   $Generics.create(PageLoaderElement currentContext)
@@ -17,8 +15,8 @@ class $Generics<T> extends Generics<T> with $$Generics<T> {
   }
   factory $Generics.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Generics is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Generics is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Generics". Requires @CheckTag annotation in order for "tagName" to be generated.';
   String typeDefParameter(T thing, MyGenericTypeDef<T> typeDef) {
@@ -31,14 +29,17 @@ class $Generics<T> extends Generics<T> with $$Generics<T> {
     }
     return returnMe;
   }
+
+  String toStringDeep() => 'Generics\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Generics<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $RootPo<T> extends RootPo<T> with $$RootPo<T> {
   PageLoaderElement $__root__;
   $RootPo.create(PageLoaderElement currentContext)
@@ -47,15 +48,16 @@ class $RootPo<T> extends RootPo<T> with $$RootPo<T> {
   }
   factory $RootPo.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "RootPo is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "RootPo is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "RootPo". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'RootPo\n\n${$__root__.toStringDeep()}';
 }
 
 class $$RootPo<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   Generics<T> get generics {
     for (final __listener in $__root__.listeners) {

--- a/test/src/list.g.dart
+++ b/test/src/list.g.dart
@@ -7,8 +7,6 @@ part of 'list.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $Lists extends Lists with $$Lists {
   PageLoaderElement $__root__;
   $Lists.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -16,15 +14,16 @@ class $Lists extends Lists with $$Lists {
   }
   factory $Lists.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Lists is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Lists is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Lists". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'Lists\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Lists {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   Future<PageObjectList<PageLoaderElement>> get tableRows async {
     for (final __listener in $__root__.listeners) {
@@ -66,6 +65,7 @@ class $$Lists {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $RowPO extends RowPO with $$RowPO {
   PageLoaderElement $__root__;
   $RowPO.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -73,7 +73,7 @@ class $RowPO extends RowPO with $$RowPO {
   }
   factory $RowPO.lookup(PageLoaderSource source) =>
       $RowPO.create(source.byTag('tr'));
-  static String get tagName => 'tr';
+  static const String tagName = 'tr';
   bool get exists {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('RowPO', 'exists');
@@ -84,11 +84,13 @@ class $RowPO extends RowPO with $$RowPO {
     }
     return returnMe;
   }
+
+  String toStringDeep() => 'RowPO\n\n${$__root__.toStringDeep()}';
 }
 
 class $$RowPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get _root {
     for (final __listener in $__root__.listeners) {

--- a/test/src/mouse.g.dart
+++ b/test/src/mouse.g.dart
@@ -7,8 +7,6 @@ part of 'mouse.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $PageForMouseTest extends PageForMouseTest with $$PageForMouseTest {
   PageLoaderElement $__root__;
   $PageForMouseTest.create(PageLoaderElement currentContext)
@@ -17,15 +15,16 @@ class $PageForMouseTest extends PageForMouseTest with $$PageForMouseTest {
   }
   factory $PageForMouseTest.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PageForMouseTest is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PageForMouseTest is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PageForMouseTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'PageForMouseTest\n\n${$__root__.toStringDeep()}';
 }
 
 class $$PageForMouseTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get element {
     for (final __listener in $__root__.listeners) {

--- a/test/src/null_element.g.dart
+++ b/test/src/null_element.g.dart
@@ -15,8 +15,8 @@ class $BasePO extends BasePO with $$BasePO {
   }
   factory $BasePO.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "BasePO is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "BasePO is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "BasePO". Requires @CheckTag annotation in order for "tagName" to be generated.';
   List<PageLoaderElement> get allRows {
@@ -52,7 +52,7 @@ class $$BasePO {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('BasePO', 'button');
     }
-    final element = $__root__.createElement(const ById('button-1'), [], []);
+    final element = $__root__.createElement(ById('button-1'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('BasePO', 'button');
@@ -76,7 +76,7 @@ class $$BasePO {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('BasePO', 'buttonPO');
     }
-    final element = $__root__.createElement(const ById('button-1'), [], []);
+    final element = $__root__.createElement(ById('button-1'), [], []);
     final returnMe = ButtonPO.create(element);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('BasePO', 'buttonPO');
@@ -125,7 +125,7 @@ class $$BasePO {
       __listener.startPageObjectMethod('BasePO', '_rowElements');
     }
     final returnMe = PageObjectList<PageLoaderElement>(
-        $__root__.createList(const ByTagName('tr'), [], []),
+        $__root__.createList(ByTagName('tr'), [], []),
         (PageLoaderElement e) => e);
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('BasePO', '_rowElements');
@@ -138,7 +138,7 @@ class $$BasePO {
       __listener.startPageObjectMethod('BasePO', '_rowPOs');
     }
     final returnMe = PageObjectList<RowPO>(
-        $__root__.createList(const ByTagName('tr'), [], []),
+        $__root__.createList(ByTagName('tr'), [], []),
         (PageLoaderElement e) => RowPO.create(e));
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('BasePO', '_rowPOs');
@@ -156,8 +156,8 @@ class $ButtonPO extends ButtonPO with $$ButtonPO {
   }
   factory $ButtonPO.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "ButtonPO is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "ButtonPO is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "ButtonPO". Requires @CheckTag annotation in order for "tagName" to be generated.';
   String toStringDeep() => 'ButtonPO\n\n${$__root__.toStringDeep()}';
@@ -177,8 +177,8 @@ class $RowPO extends RowPO with $$RowPO {
   }
   factory $RowPO.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "RowPO is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "RowPO is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "RowPO". Requires @CheckTag annotation in order for "tagName" to be generated.';
   String toStringDeep() => 'RowPO\n\n${$__root__.toStringDeep()}';

--- a/test/src/properties.g.dart
+++ b/test/src/properties.g.dart
@@ -7,8 +7,6 @@ part of 'properties.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $PageForPropertiesTests extends PageForPropertiesTests
     with $$PageForPropertiesTests {
   PageLoaderElement $__root__;
@@ -18,15 +16,17 @@ class $PageForPropertiesTests extends PageForPropertiesTests
   }
   factory $PageForPropertiesTests.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PageForPropertiesTests is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PageForPropertiesTests is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PageForPropertiesTests". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() =>
+      'PageForPropertiesTests\n\n${$__root__.toStringDeep()}';
 }
 
 class $$PageForPropertiesTests {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get divWithStyle {
     for (final __listener in $__root__.listeners) {

--- a/test/src/shared_list_page_objects.g.dart
+++ b/test/src/shared_list_page_objects.g.dart
@@ -7,8 +7,6 @@ part of 'shared_list_page_objects.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $PageForSimpleTest extends PageForSimpleTest with $$PageForSimpleTest {
   PageLoaderElement $__root__;
   $PageForSimpleTest.create(PageLoaderElement currentContext)
@@ -17,15 +15,16 @@ class $PageForSimpleTest extends PageForSimpleTest with $$PageForSimpleTest {
   }
   factory $PageForSimpleTest.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PageForSimpleTest is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PageForSimpleTest is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PageForSimpleTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'PageForSimpleTest\n\n${$__root__.toStringDeep()}';
 }
 
 class $$PageForSimpleTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get rootElement {
     for (final __listener in $__root__.listeners) {
@@ -52,6 +51,7 @@ class $$PageForSimpleTest {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $Table extends Table with $$Table {
   PageLoaderElement $__root__;
   $Table.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -59,15 +59,16 @@ class $Table extends Table with $$Table {
   }
   factory $Table.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Table is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Table is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Table". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'Table\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Table {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get table {
     for (final __listener in $__root__.listeners) {
@@ -108,6 +109,7 @@ class $$Table {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $Row extends Row with $$Row {
   PageLoaderElement $__root__;
   $Row.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -115,15 +117,16 @@ class $Row extends Row with $$Row {
   }
   factory $Row.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Row is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Row is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Row". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'Row\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Row {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get rootElement {
     for (final __listener in $__root__.listeners) {

--- a/test/src/shared_page_objects.g.dart
+++ b/test/src/shared_page_objects.g.dart
@@ -7,8 +7,6 @@ part of 'shared_page_objects.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $PageForSimpleTest extends PageForSimpleTest with $$PageForSimpleTest {
   PageLoaderElement $__root__;
   $PageForSimpleTest.create(PageLoaderElement currentContext)
@@ -17,15 +15,16 @@ class $PageForSimpleTest extends PageForSimpleTest with $$PageForSimpleTest {
   }
   factory $PageForSimpleTest.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PageForSimpleTest is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PageForSimpleTest is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PageForSimpleTest". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'PageForSimpleTest\n\n${$__root__.toStringDeep()}';
 }
 
 class $$PageForSimpleTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   Table get table {
     for (final __listener in $__root__.listeners) {
@@ -40,6 +39,7 @@ class $$PageForSimpleTest {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $Table extends Table with $$Table {
   PageLoaderElement $__root__;
   $Table.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -47,8 +47,8 @@ class $Table extends Table with $$Table {
   }
   factory $Table.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Table is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Table is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Table". Requires @CheckTag annotation in order for "tagName" to be generated.';
   Future doSlowAction() {
@@ -61,11 +61,13 @@ class $Table extends Table with $$Table {
     }
     return returnMe;
   }
+
+  String toStringDeep() => 'Table\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Table {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get table {
     for (final __listener in $__root__.listeners) {
@@ -93,6 +95,7 @@ class $$Table {
   }
 }
 
+// ignore_for_file: private_collision_in_mixin_application
 class $Row extends Row with $$Row {
   PageLoaderElement $__root__;
   $Row.create(PageLoaderElement currentContext) : $__root__ = currentContext {
@@ -100,15 +103,16 @@ class $Row extends Row with $$Row {
   }
   factory $Row.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "Row is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "Row is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "Row". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'Row\n\n${$__root__.toStringDeep()}';
 }
 
 class $$Row {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageObjectIterable<PageLoaderElement> get cells {
     for (final __listener in $__root__.listeners) {

--- a/test/src/typing.g.dart
+++ b/test/src/typing.g.dart
@@ -1,3 +1,5 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
 part of 'typing.dart';
 
 // **************************************************************************
@@ -14,8 +16,8 @@ class $PageForTextAreaTypingText extends PageForTextAreaTypingText
   }
   factory $PageForTextAreaTypingText.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PageForTextAreaTypingText is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PageForTextAreaTypingText is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PageForTextAreaTypingText". Requires @CheckTag annotation in order for "tagName" to be generated.';
   String toStringDeep() =>
@@ -30,7 +32,7 @@ class $$PageForTextAreaTypingText {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForTextAreaTypingText', 'textArea');
     }
-    final element = $__root__.createElement(const ById('textarea'), [], []);
+    final element = $__root__.createElement(ById('textarea'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForTextAreaTypingText', 'textArea');
@@ -48,8 +50,8 @@ class $PageForTypingTests extends PageForTypingTests with $$PageForTypingTests {
   }
   factory $PageForTypingTests.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PageForTypingTests is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PageForTypingTests is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PageForTypingTests". Requires @CheckTag annotation in order for "tagName" to be generated.';
   String toStringDeep() => 'PageForTypingTests\n\n${$__root__.toStringDeep()}';
@@ -63,7 +65,7 @@ class $$PageForTypingTests {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForTypingTests', 'text');
     }
-    final element = $__root__.createElement(const ById('text'), [], []);
+    final element = $__root__.createElement(ById('text'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('PageForTypingTests', 'text');
@@ -83,8 +85,8 @@ class $PageForTypingTestsWithFocusAndBlur
   }
   factory $PageForTypingTestsWithFocusAndBlur.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "PageForTypingTestsWithFocusAndBlur is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "PageForTypingTestsWithFocusAndBlur is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "PageForTypingTestsWithFocusAndBlur". Requires @CheckTag annotation in order for "tagName" to be generated.';
   int get focusCount {
@@ -127,7 +129,7 @@ class $$PageForTypingTestsWithFocusAndBlur {
           'PageForTypingTestsWithFocusAndBlur', 'text');
     }
     final element =
-        $__root__.createElement(const ById('text-with-focus-and-blur'), [], []);
+        $__root__.createElement(ById('text-with-focus-and-blur'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod(
@@ -141,8 +143,8 @@ class $$PageForTypingTestsWithFocusAndBlur {
       __listener.startPageObjectMethod(
           'PageForTypingTestsWithFocusAndBlur', '_focusCount');
     }
-    final element = $__root__.createElement(
-        const ById('text-with-focus-and-blur-focus-count'), [], []);
+    final element = $__root__
+        .createElement(ById('text-with-focus-and-blur-focus-count'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod(
@@ -156,8 +158,8 @@ class $$PageForTypingTestsWithFocusAndBlur {
       __listener.startPageObjectMethod(
           'PageForTypingTestsWithFocusAndBlur', '_blurCount');
     }
-    final element = $__root__.createElement(
-        const ById('text-with-focus-and-blur-blur-count'), [], []);
+    final element = $__root__
+        .createElement(ById('text-with-focus-and-blur-blur-count'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod(
@@ -176,8 +178,8 @@ class $KeyboardListenerPO extends KeyboardListenerPO with $$KeyboardListenerPO {
   }
   factory $KeyboardListenerPO.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "KeyboardListenerPO is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "KeyboardListenerPO is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "KeyboardListenerPO". Requires @CheckTag annotation in order for "tagName" to be generated.';
   String toStringDeep() => 'KeyboardListenerPO\n\n${$__root__.toStringDeep()}';
@@ -191,8 +193,7 @@ class $$KeyboardListenerPO {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('KeyboardListenerPO', 'listener');
     }
-    final element =
-        $__root__.createElement(const ById('keyboard-listener'), [], []);
+    final element = $__root__.createElement(ById('keyboard-listener'), [], []);
     final returnMe = element;
     for (final __listener in $__root__.listeners) {
       __listener.endPageObjectMethod('KeyboardListenerPO', 'listener');

--- a/test/src/webdriver_only.g.dart
+++ b/test/src/webdriver_only.g.dart
@@ -7,8 +7,6 @@ part of 'webdriver_only.dart';
 // **************************************************************************
 
 // ignore_for_file: private_collision_in_mixin_application
-// ignore_for_file: unused_field, non_constant_identifier_names
-// ignore_for_file: overridden_fields, annotate_overrides
 class $WebDriverOnly extends WebDriverOnly with $$WebDriverOnly {
   PageLoaderElement $__root__;
   $WebDriverOnly.create(PageLoaderElement currentContext)
@@ -17,15 +15,16 @@ class $WebDriverOnly extends WebDriverOnly with $$WebDriverOnly {
   }
   factory $WebDriverOnly.lookup(PageLoaderSource source) =>
       throw "'lookup' constructor for class "
-      "WebDriverOnly is not generated and can only be used on Page Object "
-      "classes that have @CheckTag annotation.";
+          "WebDriverOnly is not generated and can only be used on Page Object "
+          "classes that have @CheckTag annotation.";
   static String get tagName =>
       throw '"tagName" is not defined by Page Object "WebDriverOnly". Requires @CheckTag annotation in order for "tagName" to be generated.';
+  String toStringDeep() => 'WebDriverOnly\n\n${$__root__.toStringDeep()}';
 }
 
 class $$WebDriverOnly {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__; // ignore: unused_field
+  PageLoaderMouse __mouse__;
   PageLoaderElement get $root => $__root__;
   PageLoaderElement get button1 {
     for (final __listener in $__root__.listeners) {


### PR DESCRIPTION
Using the old version is preventing some pub solves in other packages.

- Bump `built_value` and `build_value_generator` dependencies.
- Regenerate .g.dart files.