### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/lib/src/api/iterable_interfaces.dart
+++ b/lib/src/api/iterable_interfaces.dart
@@ -19,8 +19,6 @@
 
 library pageloader.api.iterable_interfaces;
 
-import 'dart:async';
-
 import 'page_loader_element_interface.dart';
 
 /// Function for constructing a page object.

--- a/lib/src/api/null_page_loader_element.dart
+++ b/lib/src/api/null_page_loader_element.dart
@@ -10,7 +10,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import 'dart:async';
 import 'dart:math';
 
 import 'annotation_interfaces.dart';

--- a/lib/src/api/page_loader_element_interface.dart
+++ b/lib/src/api/page_loader_element_interface.dart
@@ -13,7 +13,6 @@
 
 library pageloader.api.page_loader_element_interface;
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 

--- a/lib/src/api/page_loader_mouse_interface.dart
+++ b/lib/src/api/page_loader_mouse_interface.dart
@@ -13,7 +13,6 @@
 
 library pageloader.api.page_loader_mouse_interface;
 
-import 'dart:async';
 import 'dart:core';
 
 import 'package:webdriver/sync_core.dart' show MouseButton;

--- a/lib/src/api/page_loader_pointer_interface.dart
+++ b/lib/src/api/page_loader_pointer_interface.dart
@@ -13,7 +13,6 @@
 
 library pageloader.api.page_loader_pointer_interface;
 
-import 'dart:async';
 import 'dart:core';
 
 import 'package:webdriver/sync_core.dart' show MouseButton;

--- a/lib/src/generators/pageobject_generator.dart
+++ b/lib/src/generators/pageobject_generator.dart
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 

--- a/lib/src/html/html_iterators.dart
+++ b/lib/src/html/html_iterators.dart
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:html';
 
 import 'package:pageloader/pageloader.dart';

--- a/lib/src/webdriver/webdriver_iterators.dart
+++ b/lib/src/webdriver/webdriver_iterators.dart
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
 import 'package:pageloader/pageloader.dart';
 import 'package:webdriver/sync_core.dart' as wd;
 

--- a/lib/src/webdriver/webdriver_mouse.dart
+++ b/lib/src/webdriver/webdriver_mouse.dart
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:core';
 
 import 'package:pageloader/pageloader.dart';

--- a/lib/src/webdriver/webdriver_page_loader_element.dart
+++ b/lib/src/webdriver/webdriver_page_loader_element.dart
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:math';
 
 import 'package:pageloader/core.dart' as core;

--- a/lib/src/webdriver/webdriver_pointer.dart
+++ b/lib/src/webdriver/webdriver_pointer.dart
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:core';
 
 import 'package:pageloader/pageloader.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.36.0 <0.40.0'
+  analyzer: '>=0.36.0 <0.41'
   build: '>0.12.7 <2.0.0'
   built_value: ^7.0.0
   build_config: '>=0.3.1 <5.0.0'

--- a/test/examples/correct/list.dart
+++ b/test/examples/correct/list.dart
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'package:pageloader/pageloader.dart';
 
 import 'finders.dart' show CheckTagPO;

--- a/test/generation_test_setup/dummy_page_loader_element.dart
+++ b/test/generation_test_setup/dummy_page_loader_element.dart
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:core';
 import 'dart:math';
 

--- a/test/setup/webdriver_environment.dart
+++ b/test/setup/webdriver_environment.dart
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
 import 'package:pageloader/webdriver.dart';
 import 'package:webdriver/sync_io.dart';
 

--- a/test/src/list.dart
+++ b/test/src/list.dart
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'package:pageloader/pageloader.dart';
 import 'package:test/test.dart';
 

--- a/test/src/shared_list_page_objects.dart
+++ b/test/src/shared_list_page_objects.dart
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
 import 'package:pageloader/pageloader.dart';
 import 'package:test/test.dart';
 

--- a/test/src/source_support.dart
+++ b/test/src/source_support.dart
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/analysis/session.dart';


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core