### PR TITLE
Sync to internal and bump versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
   chrome: stable
 
 dart:
-  - dev
+  - "2.9.3"
 
 before_install:
   - export CHROMEDRIVER_BINARY=/usr/bin/google-chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,7 @@ sudo: required
 dist: trusty
 
 addons:
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - google-chrome-stable
+  chrome: stable
 
 dart:
   - "2.9.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: dart
 sudo: required
 dist: xenial
 
+services:
+  - xvfb
+
 addons:
   chrome: stable
 
@@ -13,7 +16,6 @@ before_install:
   - export CHROMEDRIVER_ARGS=--no-sandbox
   - /usr/bin/google-chrome --version
   - export DISPLAY=:99.0
-  - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give time for xvfb to start
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ sudo: required
 dist: trusty
 
 addons:
-  chrome: stable
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
 
 dart:
   - "2.9.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 sudo: required
-dist: trusty
+dist: xenial
 
 addons:
   chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ before_install:
   - sleep 3 # give time for xvfb to start
 
 before_script:
-#  - wget http://chromedriver.storage.googleapis.com/77.0.3865.40/chromedriver_linux64.zip
-  - wget http://chromedriver.storage.googleapis.com/2.35/chromedriver_linux64.zip
+  - wget http://chromedriver.storage.googleapis.com/91.0.4472.19/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - export PATH=$PATH:$PWD
   - ./tool/travis-setup.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 3.3.2
+
+- Bump dependencies up until but not included null safety versions.
+- Stop using deprecated API calls from `analyzer`.
+- Remove violations of `private_collision_in_mixin_application`.
+- Fix generated code to be compatible with `implicit_casts: false`.
+- Use `<int>` type parameter with `Point`.
+- Use `Iterator` in HTML/Webdriver iterators to prevent explicit `null` returns.
+- Syntactical changes to make null safety migration easier.
+- `HtmlPageLoaderElement` sends `key` property value on keyboard usage.
+- Add support for `shadowDomChildren`. `shadowDom` is still not supported since it does not return a singular `Element`. However, users may still need to access its children elements.
+- Make errors from `@CheckTag`/`@CheckTags` more descriptive.
+- Remove usages of `dart:async` imports; they're part of `dart:core` now.
+- Improve error message on `isFocused` test matcher.
+- Respect `clickOption` in `HtmlPageLoaderElement`'s `click()` method.
+- Make `WebdriverPageLoaderElement`'s click more tolerant to changed views ports.
+- Check whether a `WebdriverPageLoaderElement` is displayed or not on `visibleText` and `click`.
+
 ## 3.3.1
 
 - Fix bug where type parameters were not being passed as args into generated

--- a/lib/src/api/iterable_interfaces.dart
+++ b/lib/src/api/iterable_interfaces.dart
@@ -19,8 +19,6 @@
 
 library pageloader.api.iterable_interfaces;
 
-import 'dart:async';
-
 import 'page_loader_element_interface.dart';
 
 /// Function for constructing a page object.

--- a/lib/src/api/null_page_loader_element.dart
+++ b/lib/src/api/null_page_loader_element.dart
@@ -10,7 +10,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import 'dart:async';
 import 'dart:math';
 
 import 'annotation_interfaces.dart';
@@ -70,6 +69,10 @@ class NullPageLoaderElement implements PageLoaderElement {
   @override
   PageLoaderElement get shadowRoot =>
       throw NullPageLoaderElementAccessException('shadowRoot', this);
+
+  @override
+  List<PageLoaderElement> get shadowRootChildren =>
+      throw NullPageLoaderElementAccessException('shadowRootChildren', this);
 
   @override
   String get id => '<id>';

--- a/lib/src/api/page_loader_element_interface.dart
+++ b/lib/src/api/page_loader_element_interface.dart
@@ -13,7 +13,6 @@
 
 library pageloader.api.page_loader_element_interface;
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 
@@ -75,6 +74,9 @@ abstract class PageLoaderElement extends PageLoaderSource {
 
   /// The shadow root hosted by this element.
   PageLoaderElement get shadowRoot;
+
+  /// The children of the shadow root hosted by this element.
+  List<PageLoaderElement> get shadowRootChildren;
 
   /// Unique ID to identify the element.
   ///

--- a/lib/src/api/page_loader_keyboard.dart
+++ b/lib/src/api/page_loader_keyboard.dart
@@ -121,6 +121,7 @@ class PageLoaderKeyboard {
   /// [keyDown] and [keyUp] determines whether those events should be sent.
   void typeSpecialKey(PageLoaderSpecialKey key,
       {bool keyDown = true, bool keyUp = true}) {
+    final keyString = _specialKeyToKeyProperty[key];
     if (keyDown) {
       switch (key) {
         case PageLoaderSpecialKey.alt:
@@ -138,11 +139,11 @@ class PageLoaderKeyboard {
         default:
           break;
       }
-      _addEvent(key, null, KeyboardEventType.keyDown);
+      _addEvent(key, keyString, KeyboardEventType.keyDown);
 
       // 'enter' still sends a keypress.
       if (key == PageLoaderSpecialKey.enter) {
-        _addEvent(key, null, KeyboardEventType.keyPress);
+        _addEvent(key, keyString, KeyboardEventType.keyPress);
       }
     }
     if (keyUp) {
@@ -162,9 +163,9 @@ class PageLoaderKeyboard {
         default:
           break;
       }
-      _addEvent(key, null, KeyboardEventType.keyUp);
+      _addEvent(key, keyString, KeyboardEventType.keyUp);
     }
-    _addUniqueEvent(key, null);
+    _addUniqueEvent(key, keyString);
   }
 }
 
@@ -222,6 +223,42 @@ enum PageLoaderSpecialKey {
   f12,
   meta,
 }
+
+// Mapping of special keys to its key string value.
+// Based on: https://www.w3.org/TR/uievents-key/#key-string
+const _specialKeyToKeyProperty = {
+  PageLoaderSpecialKey.backSpace: 'Backspace',
+  PageLoaderSpecialKey.tab: 'Tab',
+  PageLoaderSpecialKey.enter: 'Enter',
+  PageLoaderSpecialKey.shift: 'Shift',
+  PageLoaderSpecialKey.control: 'Control',
+  PageLoaderSpecialKey.alt: 'Alt',
+  PageLoaderSpecialKey.pause: 'Pause',
+  PageLoaderSpecialKey.escape: 'Escape',
+  PageLoaderSpecialKey.pageUp: 'PageUp',
+  PageLoaderSpecialKey.pageDown: 'PageDown',
+  PageLoaderSpecialKey.end: 'End',
+  PageLoaderSpecialKey.home: 'Home',
+  PageLoaderSpecialKey.left: 'ArrowLeft',
+  PageLoaderSpecialKey.up: 'ArrowUp',
+  PageLoaderSpecialKey.right: 'ArrowRight',
+  PageLoaderSpecialKey.down: 'ArrowDown',
+  PageLoaderSpecialKey.insert: 'Insert',
+  PageLoaderSpecialKey.delete: 'Delete',
+  PageLoaderSpecialKey.f1: 'F1',
+  PageLoaderSpecialKey.f2: 'F2',
+  PageLoaderSpecialKey.f3: 'F3',
+  PageLoaderSpecialKey.f4: 'F4',
+  PageLoaderSpecialKey.f5: 'F5',
+  PageLoaderSpecialKey.f6: 'F6',
+  PageLoaderSpecialKey.f7: 'F7',
+  PageLoaderSpecialKey.f8: 'F8',
+  PageLoaderSpecialKey.f9: 'F9',
+  PageLoaderSpecialKey.f10: 'F10',
+  PageLoaderSpecialKey.f11: 'F11',
+  PageLoaderSpecialKey.f12: 'F12',
+  PageLoaderSpecialKey.meta: 'Meta',
+};
 
 /// Keyboard event type.
 enum KeyboardEventType {

--- a/lib/src/api/page_loader_mouse_interface.dart
+++ b/lib/src/api/page_loader_mouse_interface.dart
@@ -13,7 +13,6 @@
 
 library pageloader.api.page_loader_mouse_interface;
 
-import 'dart:async';
 import 'dart:core';
 
 import 'package:webdriver/sync_core.dart' show MouseButton;

--- a/lib/src/api/page_loader_pointer_interface.dart
+++ b/lib/src/api/page_loader_pointer_interface.dart
@@ -13,7 +13,6 @@
 
 library pageloader.api.page_loader_pointer_interface;
 
-import 'dart:async';
 import 'dart:core';
 
 import 'package:webdriver/sync_core.dart' show MouseButton;

--- a/lib/src/core/core.dart
+++ b/lib/src/core/core.dart
@@ -35,7 +35,10 @@ List<PageLoaderElement> applyFiltersAndChecks(List<PageLoaderElement> elements,
   for (final element in filteredElements) {
     for (final check in checkers) {
       if (!check.check(element)) {
-        throw PageLoaderException('Failed check: ${check.toString()}', element);
+        throw PageLoaderException(
+            'Failed check: ${check.toString()}. '
+            'Found "${element.name.toLowerCase()}" instead.',
+            element);
       }
     }
   }

--- a/lib/src/generators/collector_visitor.dart
+++ b/lib/src/generators/collector_visitor.dart
@@ -84,10 +84,6 @@ class CollectorVisitor extends GeneralizingAstVisitor<void> {
     writeFindChainInMixin(mixinBuffer, className);
     final addToMixin =
         (method) => mixinBuffer.writeln(method.generate(className));
-    getters.forEach(
-        (getter) => mixinBuffer.writeln(getter.generateForMixin(className)));
-    setters.forEach(
-        (setter) => mixinBuffer.writeln(setter.generateForMixin(className)));
     singleFinderMethods.forEach(addToMixin);
     iterableFinderMethods.forEach(addToMixin);
     listFinderMethods.forEach(addToMixin);

--- a/lib/src/generators/methods/annotation_evaluators.dart
+++ b/lib/src/generators/methods/annotation_evaluators.dart
@@ -15,8 +15,6 @@
 /// and returns its kind.
 library pageloader.annotation_evaluators;
 
-import 'dart:collection' show Queue;
-
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
@@ -45,32 +43,25 @@ Set<AnnotationKind> evaluateAsAtomicAnnotation(Element element) {
 /// Finder, Checker, and/or Filter.
 Set<AnnotationKind> evaluateAsInterfaceAnnotation(Element element) {
   final returnSet = <AnnotationKind>{};
-  InterfaceType type;
-  if (element is PropertyAccessorElement) {
-    // Annotation is a top-level variable.
-    type = element.variable.type as InterfaceType;
+
+  DartType type;
+  if (element is PropertyAccessorElement && element.isGetter) {
+    type = element.returnType;
   } else if (element is ConstructorElement) {
-    // Annotation is an named constructor.
-    type = element.enclosingElement.type;
-  } else if (element is ClassElement) {
-    // Annotation is no-name constructor.
-    type = element.type;
+    type = element.returnType;
   }
 
-  if (type != null) {
-    final types = Queue<InterfaceType>()..add(type);
+  if (type is InterfaceType) {
     final seenValidAnnotations = <AnnotationKind>{};
-    do {
-      type = types.removeFirst();
-      if (type.element.library.name == pageLoaderAnnotationInterface) {
-        seenValidAnnotations
-            .add(classNameToAnnotationKind(type.element.name, isAtomic: false));
+    final interfaces = [type, ...type.allSupertypes];
+    for (var interface in interfaces) {
+      final interfaceElement = interface.element;
+      if (interfaceElement.library.name == pageLoaderAnnotationInterface) {
+        seenValidAnnotations.add(
+          classNameToAnnotationKind(interfaceElement.name, isAtomic: false),
+        );
       }
-      types..addAll(type.interfaces)..addAll(type.mixins);
-      if (type.superclass != null) {
-        types.add(type.superclass);
-      }
-    } while (types.isNotEmpty);
+    }
     returnSet.addAll(seenValidAnnotations.where((ak) => ak != null));
   }
   return returnSet;

--- a/lib/src/generators/methods/annotation_evaluators.dart
+++ b/lib/src/generators/methods/annotation_evaluators.dart
@@ -15,6 +15,8 @@
 /// and returns its kind.
 library pageloader.annotation_evaluators;
 
+import 'dart:collection' show Queue;
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
@@ -43,25 +45,32 @@ Set<AnnotationKind> evaluateAsAtomicAnnotation(Element element) {
 /// Finder, Checker, and/or Filter.
 Set<AnnotationKind> evaluateAsInterfaceAnnotation(Element element) {
   final returnSet = <AnnotationKind>{};
-
-  DartType type;
-  if (element is PropertyAccessorElement && element.isGetter) {
-    type = element.returnType;
+  InterfaceType type;
+  if (element is PropertyAccessorElement) {
+    // Annotation is a top-level variable.
+    type = element.variable.type as InterfaceType;
   } else if (element is ConstructorElement) {
-    type = element.returnType;
+    // Annotation is an named constructor.
+    type = element.enclosingElement.type;
+  } else if (element is ClassElement) {
+    // Annotation is no-name constructor.
+    type = element.type;
   }
 
-  if (type is InterfaceType) {
+  if (type != null) {
+    final types = Queue<InterfaceType>()..add(type);
     final seenValidAnnotations = <AnnotationKind>{};
-    final interfaces = [type as InterfaceType, ...type.allSupertypes];
-    for (var interface in interfaces) {
-      final interfaceElement = interface.element;
-      if (interfaceElement.library.name == pageLoaderAnnotationInterface) {
-        seenValidAnnotations.add(
-          classNameToAnnotationKind(interfaceElement.name, isAtomic: false),
-        );
+    do {
+      type = types.removeFirst();
+      if (type.element.library.name == pageLoaderAnnotationInterface) {
+        seenValidAnnotations
+            .add(classNameToAnnotationKind(type.element.name, isAtomic: false));
       }
-    }
+      types..addAll(type.interfaces)..addAll(type.mixins);
+      if (type.superclass != null) {
+        types.add(type.superclass);
+      }
+    } while (types.isNotEmpty);
     returnSet.addAll(seenValidAnnotations.where((ak) => ak != null));
   }
   return returnSet;

--- a/lib/src/generators/methods/annotation_evaluators.dart
+++ b/lib/src/generators/methods/annotation_evaluators.dart
@@ -53,7 +53,7 @@ Set<AnnotationKind> evaluateAsInterfaceAnnotation(Element element) {
 
   if (type is InterfaceType) {
     final seenValidAnnotations = <AnnotationKind>{};
-    final interfaces = [type, ...type.allSupertypes];
+    final interfaces = [type as InterfaceType, ...type.allSupertypes];
     for (var interface in interfaces) {
       final interfaceElement = interface.element;
       if (interfaceElement.library.name == pageLoaderAnnotationInterface) {

--- a/lib/src/generators/methods/core.dart
+++ b/lib/src/generators/methods/core.dart
@@ -173,3 +173,8 @@ DartType getInnerType(DartType topType, String matchingType) {
   }
   return getInnerType(first, matchingType);
 }
+
+/// Return the Dart code the corresponds to the [type].
+String typeToCode(DartType type) {
+  return type?.getDisplayString(withNullability: false);
+}

--- a/lib/src/generators/methods/getter.dart
+++ b/lib/src/generators/methods/getter.dart
@@ -69,8 +69,6 @@ abstract class Getter implements Built<Getter, GetterBuilder> {
         'return returnMe; }';
   }
 
-  String generateForMixin(String pageObjectName) => '$returnType get $name;';
-
   /// Generates code that given list of [PageLoaderElement] ids called
   /// `internalIds`, determine whether and where this getter appears in the list
   /// and what code should be further generated for this.
@@ -96,7 +94,8 @@ abstract class Getter implements Built<Getter, GetterBuilder> {
       try {
         // Do not know the type. Try it out and ignore if not successful.
         var ${name}Element = this.$name as dynamic;
-        var ${name}Index = internalIds.indexOf(${name}Element.\$__root__.id);
+        var ${name}Index = internalIds
+            .indexOf(${name}Element.\$__root__.id as String);
         if (${name}Index >= 0 && ${name}Index < closestIndex) {
           closestIndex = ${name}Index;
           closestValue = (ids) =>

--- a/lib/src/generators/methods/list_finder_method.dart
+++ b/lib/src/generators/methods/list_finder_method.dart
@@ -130,7 +130,8 @@ abstract class ListFinderMethodMixin {
   String get createChainIndex => listTypeArgument == 'PageLoaderElement'
       ? 'var ${name}Index = internalIds.indexOf(${name}Elements[elementIter].id);'
       : '''var ${name}Element = ${name}Elements[elementIter] as dynamic;
-           var ${name}Index = internalIds.indexOf(${name}Element.\$__root__.id);''';
+           var ${name}Index = internalIds
+               .indexOf(${name}Element.\$__root__.id as String);''';
 
   String get chainValueCreation => createChainValue;
 

--- a/lib/src/generators/methods/setter.dart
+++ b/lib/src/generators/methods/setter.dart
@@ -17,6 +17,8 @@ library pageloader.setter;
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:built_value/built_value.dart';
 import 'package:quiver/core.dart';
+
+import 'core.dart';
 import 'listeners.dart';
 
 part 'setter.g.dart';
@@ -26,7 +28,7 @@ Optional<Setter> collectUnannotatedSetter(MethodDeclaration node) {
   if (!node.isAbstract && node.isSetter) {
     final param = node.parameters.parameters.first;
     return Optional.of(Setter((b) => b
-      ..name = node.name.toString()
+      ..name = typeToCode(param.declaredElement.type)
       ..setterType = param.declaredElement.type.toString()
       ..setterValueName = param.declaredElement.name));
   }
@@ -49,9 +51,6 @@ abstract class Setter implements Built<Setter, SetterBuilder> {
         'return;'
             '}';
   }
-
-  String generateForMixin(String pageObjectName) =>
-      'set $name($setterType $setterValueName);';
 
   factory Setter([Function(SetterBuilder) updates]) = _$Setter;
 

--- a/lib/src/generators/methods/setter.dart
+++ b/lib/src/generators/methods/setter.dart
@@ -28,8 +28,8 @@ Optional<Setter> collectUnannotatedSetter(MethodDeclaration node) {
   if (!node.isAbstract && node.isSetter) {
     final param = node.parameters.parameters.first;
     return Optional.of(Setter((b) => b
-      ..name = typeToCode(param.declaredElement.type)
-      ..setterType = param.declaredElement.type.toString()
+      ..name = node.name.toString()
+      ..setterType = typeToCode(param.declaredElement.type)
       ..setterValueName = param.declaredElement.name));
   }
   return Optional.absent();

--- a/lib/src/generators/methods/single_finder_method.dart
+++ b/lib/src/generators/methods/single_finder_method.dart
@@ -216,7 +216,8 @@ abstract class SingleFinderMethodMixin {
   String get createChainIndex => pageObjectType == 'PageLoaderElement'
       ? 'var ${name}Index = internalIds.indexOf(this.$name.id);'
       : '''var ${name}Element = this.$name as dynamic;
-           var ${name}Index = internalIds.indexOf(${name}Element.\$__root__.id);''';
+           var ${name}Index = internalIds
+               .indexOf(${name}Element.\$__root__.id as String);''';
 
   String get chainValueCreation => createChainValue;
 

--- a/lib/src/generators/methods/unannotated_method.dart
+++ b/lib/src/generators/methods/unannotated_method.dart
@@ -84,7 +84,7 @@ abstract class UnannotatedMethod
 
   String get _parameterDeclarations {
     final required = parameters
-        .where((p) => p.isRequired)
+        .where((p) => p.isRequired && !p.isNamed)
         .map((p) => p.toSource())
         .join(', ');
 
@@ -103,7 +103,7 @@ abstract class UnannotatedMethod
 
   String get _parameterNames {
     final required = parameters
-        .where((p) => p.isRequired)
+        .where((p) => p.isRequired && !p.isNamed)
         .map((p) => p.declaredElement.name)
         .join(', ');
 

--- a/lib/src/generators/pageobject_generator.dart
+++ b/lib/src/generators/pageobject_generator.dart
@@ -37,8 +37,14 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
       Element element, ConstantReader annotation, BuildStep buildStep) async {
     final library = element.library;
     // ignore: deprecated_member_use
+    // final resolvedLibrary =
+    //     await library.session.getResolvedLibraryByElement2(library);
+    final resolver = buildStep.resolver;
+    final tempResolvedLibrary =
+        await resolver.libraryFor(await resolver.assetIdForElement(library));
+    final session = tempResolvedLibrary.session;
     final resolvedLibrary =
-        await library.session.getResolvedLibraryByElement(library);
+        await session.getResolvedLibraryByElement(tempResolvedLibrary);
     final annotatedNode = resolvedLibrary.getElementDeclaration(element).node;
     final poAnnotation = getPageObjectAnnotation(annotation);
     if (annotatedNode is ClassOrMixinDeclaration) {

--- a/lib/src/generators/pageobject_generator.dart
+++ b/lib/src/generators/pageobject_generator.dart
@@ -37,14 +37,19 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
       Element element, ConstantReader annotation, BuildStep buildStep) async {
     final library = element.library;
     // ignore: deprecated_member_use
-    // final resolvedLibrary =
-    //     await library.session.getResolvedLibraryByElement2(library);
+    // Begin workaround
     final resolver = buildStep.resolver;
     final tempResolvedLibrary =
         await resolver.libraryFor(await resolver.assetIdForElement(library));
     final session = tempResolvedLibrary.session;
     final resolvedLibrary =
         await session.getResolvedLibraryByElement(tempResolvedLibrary);
+    // End workaround
+
+    // TODO: Once SDK & analyzer is bumped, revert workaround to below.
+    // final resolvedLibrary =
+    //     await library.session.getResolvedLibraryByElement2(library);
+
     final annotatedNode = resolvedLibrary.getElementDeclaration(element).node;
     final poAnnotation = getPageObjectAnnotation(annotation);
     if (annotatedNode is ClassOrMixinDeclaration) {

--- a/lib/src/generators/pageobject_generator.dart
+++ b/lib/src/generators/pageobject_generator.dart
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:analyzer/dart/analysis/results.dart';
-import 'package:analyzer/dart/analysis/session.dart' show InconsistentAnalysisException;
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 
@@ -39,17 +37,8 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
       Element element, ConstantReader annotation, BuildStep buildStep) async {
     final library = element.library;
     // ignore: deprecated_member_use
-    ResolvedLibraryResult resolvedLibrary;
-
-    // TODO: Remove try-catch block once sdk/analyzer is updated to null safe.
-    try {
-      resolvedLibrary =
-          await library.session.getResolvedLibraryByElement(library);
-    } on InconsistentAnalysisException {
-      // Try again.
-      resolvedLibrary =
-          await library.session.getResolvedLibraryByElement(library);
-    }
+    final resolvedLibrary =
+        await library.session.getResolvedLibraryByElement(library);
     final annotatedNode = resolvedLibrary.getElementDeclaration(element).node;
     final poAnnotation = getPageObjectAnnotation(annotation);
     if (annotatedNode is ClassOrMixinDeclaration) {

--- a/lib/src/generators/pageobject_generator.dart
+++ b/lib/src/generators/pageobject_generator.dart
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/analysis/session.dart' show InconsistentAnalysisException;
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 
@@ -37,8 +39,15 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
       Element element, ConstantReader annotation, BuildStep buildStep) async {
     final library = element.library;
     // ignore: deprecated_member_use
-    final resolvedLibrary =
-        await library.session.getResolvedLibraryByElement(library);
+    ResolvedLibraryResult resolvedLibrary;
+
+    // TODO: Remove try-catch block once sdk/analyzer is updated to null safe.
+    try {
+      resolvedLibrary =
+          await library.session.getResolvedLibraryByElement(library);
+    } on InconsistentAnalysisException {
+      // Do nothing. This is a temporary solution.
+    }
     final annotatedNode = resolvedLibrary.getElementDeclaration(element).node;
     final poAnnotation = getPageObjectAnnotation(annotation);
     if (annotatedNode is ClassOrMixinDeclaration) {

--- a/lib/src/generators/pageobject_generator.dart
+++ b/lib/src/generators/pageobject_generator.dart
@@ -46,7 +46,9 @@ class PageObjectGenerator extends GeneratorForAnnotation<PageObject> {
       resolvedLibrary =
           await library.session.getResolvedLibraryByElement(library);
     } on InconsistentAnalysisException {
-      // Do nothing. This is a temporary solution.
+      // Try again.
+      resolvedLibrary =
+          await library.session.getResolvedLibraryByElement(library);
     }
     final annotatedNode = resolvedLibrary.getElementDeclaration(element).node;
     final poAnnotation = getPageObjectAnnotation(annotation);

--- a/lib/src/html/html_iterators.dart
+++ b/lib/src/html/html_iterators.dart
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:html';
 
 import 'package:pageloader/pageloader.dart';
@@ -22,20 +21,17 @@ import 'html_page_loader_element.dart';
 class HtmlPageElementIterator extends Iterator<HtmlPageLoaderElement> {
   final SyncFn<dynamic> _syncFn;
 
-  final List<Element> _elements;
-  int _current = -1;
+  final Iterator<Element> _elements;
 
-  HtmlPageElementIterator(this._syncFn, this._elements);
+  HtmlPageElementIterator(this._syncFn, List<Element> elements)
+      : _elements = elements.iterator;
 
   @override
-  bool moveNext() => ++_current < _elements.length;
+  bool moveNext() => _elements.moveNext();
 
   @override
   HtmlPageLoaderElement get current {
-    if (_current == -1) {
-      return null;
-    }
-    return HtmlPageLoaderElement.createFromElement(_elements[_current],
+    return HtmlPageLoaderElement.createFromElement(_elements.current,
         externalSyncFn: _syncFn);
   }
 }

--- a/lib/src/html/html_mouse.dart
+++ b/lib/src/html/html_mouse.dart
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:html';
 import 'dart:math';
 import 'dart:svg' show SvgElement;
@@ -237,7 +236,7 @@ class HtmlMouse implements PageLoaderMouse {
   /// Sends 'mouseenter' to elements in [_trackedElements] if needed.
   ///
   /// Returns a list of [TrackedElement] that had 'mouseenter' sent to them.
-  Future<List<TrackedElement>> _dispatchMouseEnters(Point nextPos) async {
+  Future<List<TrackedElement>> _dispatchMouseEnters(Point<int> nextPos) async {
     final elementsThatEntered = <TrackedElement>[];
     for (final element in _trackedElements) {
       if (element.containsPoint(nextPos) && !element.mouseIsInside) {
@@ -251,7 +250,7 @@ class HtmlMouse implements PageLoaderMouse {
   /// Sends 'mouseleave' to elements in [_trackedElements] if needed.
   ///
   /// Returns a list of [TrackedElement] that had 'mouseleave' sent to them.
-  Future<List<TrackedElement>> _dispatchMouseLeaves(Point nextPos) async {
+  Future<List<TrackedElement>> _dispatchMouseLeaves(Point<int> nextPos) async {
     final elementsThatLeft = <TrackedElement>[];
     for (final element in _trackedElements) {
       if (!element.containsPoint(nextPos) && element.mouseIsInside) {
@@ -263,7 +262,7 @@ class HtmlMouse implements PageLoaderMouse {
   }
 
   /// Sends 'mousemove' to elements in [_trackedElements] if needed.
-  Future<void> _dispatchMouseMoves(Point nextPos) async {
+  Future<void> _dispatchMouseMoves(Point<int> nextPos) async {
     for (final element in _trackedElements) {
       if (element.mouseIsInside) {
         await element.dispatchMouseMove(nextPos.x, nextPos.y);
@@ -272,16 +271,18 @@ class HtmlMouse implements PageLoaderMouse {
   }
 
   /// Sends 'mouseout' to elements in [_trackedElements] if needed.
-  Future<void> _dispatchMouseOuts(Point nextPos) => _dispatchBubblingEvents(
-      (TrackedElement element) => element._isLeaving(nextPos),
-      (TrackedElement element) async =>
-          await element.dispatchMouseOut(nextPos.x, nextPos.y));
+  Future<void> _dispatchMouseOuts(Point<int> nextPos) =>
+      _dispatchBubblingEvents(
+          (TrackedElement element) => element._isLeaving(nextPos),
+          (TrackedElement element) async =>
+              await element.dispatchMouseOut(nextPos.x, nextPos.y));
 
   /// Sends 'mouseover' to elements in [_trackedElements] if needed.
-  Future<void> _dispatchMouseOvers(Point nextPos) => _dispatchBubblingEvents(
-      (TrackedElement element) => element._isEntering(nextPos),
-      (TrackedElement element) async =>
-          await element.dispatchMouseOver(nextPos.x, nextPos.y));
+  Future<void> _dispatchMouseOvers(Point<int> nextPos) =>
+      _dispatchBubblingEvents(
+          (TrackedElement element) => element._isEntering(nextPos),
+          (TrackedElement element) async =>
+              await element.dispatchMouseOver(nextPos.x, nextPos.y));
 
   /// Traverses each tree in the forest [_trackedElements] and calls
   /// [dispatcher] on the lowest element in the tree satisfying [test], exactly
@@ -349,14 +350,14 @@ class TrackedElement {
   TrackedElement(this.element);
 
   /// Returns true if point is inside element.
-  bool containsPoint(Point p) {
+  bool containsPoint(Point<int> p) {
     bounds ??= element.getBoundingClientRect();
     return bounds.containsPoint(p);
   }
 
-  bool _isEntering(Point p) => containsPoint(p) && !mouseIsInside;
+  bool _isEntering(Point<int> p) => containsPoint(p) && !mouseIsInside;
 
-  bool _isLeaving(Point p) => !containsPoint(p) && mouseIsInside;
+  bool _isLeaving(Point<int> p) => !containsPoint(p) && mouseIsInside;
 
   /// Sends mouse enter event to element.
   Future<dynamic> dispatchMouseEnter(int x, int y) =>

--- a/lib/src/html/html_page_utils.dart
+++ b/lib/src/html/html_page_utils.dart
@@ -32,18 +32,15 @@ class HtmlPageUtils extends PageUtils {
   /// Caches the [HtmlPageLoaderElement] used between calls to allow listeners
   /// to persist.
   @override
-  HtmlPageLoaderElement get root {
-    _cachedRoot ??= HtmlPageLoaderElement.createFromElement(document.body,
-        externalSyncFn: syncFn);
-    return _cachedRoot;
-  }
+  HtmlPageLoaderElement get root =>
+      _cachedRoot ??= HtmlPageLoaderElement.createFromElement(document.body,
+          externalSyncFn: syncFn);
 
   /// Gets the element on the DOM that currently has focus.
   @override
-  HtmlPageLoaderElement get focused {
-    return HtmlPageLoaderElement.createFromElement(document.activeElement,
-        externalSyncFn: syncFn);
-  }
+  HtmlPageLoaderElement get focused =>
+      HtmlPageLoaderElement.createFromElement(document.activeElement,
+          externalSyncFn: syncFn);
 
   /// Gets the current root element for the DOM.
   ///

--- a/lib/src/html/html_pointer.dart
+++ b/lib/src/html/html_pointer.dart
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:html' as html;
 import 'dart:math';
 
@@ -216,7 +215,8 @@ class HtmlPointer implements PageLoaderPointer {
   /// Sends 'pointerenter' to elements in [_trackedElements] if needed.
   ///
   /// Returns a list of [TrackedElement] that had 'pointerenter' sent to them.
-  Future<List<TrackedElement>> _dispatchPointerEnters(Point nextPos) async {
+  Future<List<TrackedElement>> _dispatchPointerEnters(
+      Point<int> nextPos) async {
     final elementsThatEntered = <TrackedElement>[];
     for (final element in _trackedElements) {
       if (element.containsPoint(nextPos) && !element.pointerIsInside) {
@@ -230,7 +230,8 @@ class HtmlPointer implements PageLoaderPointer {
   /// Sends 'pointerleave' to elements in [_trackedElements] if needed.
   ///
   /// Returns a list of [TrackedElement] that had 'pointerleave' sent to them.
-  Future<List<TrackedElement>> _dispatchPointerLeaves(Point nextPos) async {
+  Future<List<TrackedElement>> _dispatchPointerLeaves(
+      Point<int> nextPos) async {
     final elementsThatLeft = <TrackedElement>[];
     for (final element in _trackedElements) {
       if (!element.containsPoint(nextPos) && element.pointerIsInside) {
@@ -242,7 +243,7 @@ class HtmlPointer implements PageLoaderPointer {
   }
 
   /// Sends 'pointermove' to elements in [_trackedElements] if needed.
-  Future<void> _dispatchPointerMoves(Point nextPos) async {
+  Future<void> _dispatchPointerMoves(Point<int> nextPos) async {
     for (final element in _trackedElements) {
       if (element.pointerIsInside) {
         await element.dispatchPointerMove(nextPos.x, nextPos.y);
@@ -251,16 +252,19 @@ class HtmlPointer implements PageLoaderPointer {
   }
 
   /// Sends 'pointerout' to elements in [_trackedElements] if needed.
-  Future<void> _dispatchPointerOuts(Point nextPos) => _dispatchBubblingEvents(
-      (TrackedElement element) => element._isLeaving(nextPos),
-      (TrackedElement element) async =>
-          await element.dispatchPointerOut(nextPos.x, nextPos.y));
+  Future<void> _dispatchPointerOuts(Point<int> nextPos) =>
+      _dispatchBubblingEvents(
+          (TrackedElement element) => element._isLeaving(nextPos),
+          (TrackedElement element) async =>
+              await element.dispatchPointerOut(nextPos.x, nextPos.y));
 
   /// Sends 'pointerover' to elements in [_trackedElements] if needed.
-  Future<void> _dispatchPointerOvers(Point nextPos) => _dispatchBubblingEvents(
-      (TrackedElement element) => element._isEntering(nextPos),
-      (TrackedElement element) async =>
-          await element.dispatchPointerOver(nextPos.x, nextPos.y));
+  Future<void> _dispatchPointerOvers(
+          Point<int> nextPos) =>
+      _dispatchBubblingEvents(
+          (TrackedElement element) => element._isEntering(nextPos),
+          (TrackedElement element) async =>
+              await element.dispatchPointerOver(nextPos.x, nextPos.y));
 
   /// Traverses each tree in the forest [_trackedElements] and calls
   /// [dispatcher] on the lowest element in the tree satisfying [test], exactly
@@ -327,14 +331,14 @@ class TrackedElement {
   TrackedElement(this.element);
 
   /// Returns true if point is inside element.
-  bool containsPoint(Point p) {
+  bool containsPoint(Point<int> p) {
     bounds ??= element.getBoundingClientRect();
     return bounds.containsPoint(p);
   }
 
-  bool _isEntering(Point p) => containsPoint(p) && !pointerIsInside;
+  bool _isEntering(Point<int> p) => containsPoint(p) && !pointerIsInside;
 
-  bool _isLeaving(Point p) => !containsPoint(p) && pointerIsInside;
+  bool _isLeaving(Point<int> p) => !containsPoint(p) && pointerIsInside;
 
   /// Sends pointer enter event to element.
   Future dispatchPointerEnter(int x, int y) =>

--- a/lib/src/matchers/matchers.dart
+++ b/lib/src/matchers/matchers.dart
@@ -179,6 +179,33 @@ class _IsFocused extends Matcher {
   @override
   Description describe(Description description) =>
       description.add('$_item is focused');
+
+  @override
+  Description describeMismatch(dynamic item, Description mismatchDescription,
+      Map matchState, bool verbose) {
+    try {
+      final e = utils.rootElementOf(item);
+
+      // Lowercasing because it's a bit easier to read.
+      final itemId = e.id.toLowerCase();
+      final focusId = e.utils.focused.id.toLowerCase();
+
+      // Find the common prefix xpath.
+      var common = 0;
+      for (var i = 0; i < itemId.length && i < focusId.length; i++) {
+        if (itemId[i] != focusId[i]) break;
+        if (itemId[i] == '/') common = i;
+      }
+
+      final commonPrefix = itemId.substring(0, common);
+      final focusSuffix = focusId.substring(common + 1);
+      final itemSuffix = itemId.substring(common + 1);
+      return mismatchDescription.add(
+          '$focusSuffix was focused instead of $itemSuffix (in $commonPrefix)');
+    } on utils.PageLoaderArgumentError {
+      return mismatchDescription.add('$item $_invalidTypeMessage');
+    }
+  }
 }
 
 class _IsVisible extends Matcher {

--- a/lib/src/webdriver/webdriver_iterators.dart
+++ b/lib/src/webdriver/webdriver_iterators.dart
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
 import 'package:pageloader/pageloader.dart';
 import 'package:webdriver/sync_core.dart' as wd;
 
@@ -21,20 +19,17 @@ import 'webdriver_page_loader_element.dart';
 /// Iterator for [WebDriverPageLoaderElement]s.
 class WebDriverPageElementIterator
     extends Iterator<WebDriverPageLoaderElement> {
-  final List<wd.WebElement> _elements;
-  int _current = -1;
+  final Iterator<wd.WebElement> _elements;
 
-  WebDriverPageElementIterator(this._elements);
+  WebDriverPageElementIterator(List<wd.WebElement> elements)
+      : _elements = elements.iterator;
 
   @override
-  bool moveNext() => ++_current < _elements.length;
+  bool moveNext() => _elements.moveNext();
 
   @override
   WebDriverPageLoaderElement get current {
-    if (_current == -1) {
-      return null;
-    }
-    return WebDriverPageLoaderElement.createFromElement(_elements[_current]);
+    return WebDriverPageLoaderElement.createFromElement(_elements.current);
   }
 }
 

--- a/lib/src/webdriver/webdriver_mouse.dart
+++ b/lib/src/webdriver/webdriver_mouse.dart
@@ -49,7 +49,8 @@ class WebDriverMouse implements PageLoaderMouse {
           int stepPixels,
           Duration duration}) async =>
       _driver.mouse.moveTo(
-          element: (element as WebDriverPageLoaderElement).contextSync,
+          element: (element as WebDriverPageLoaderElement).contextSync
+              as wd.WebElement,
           xOffset: xOffset,
           yOffset: yOffset);
 

--- a/lib/src/webdriver/webdriver_mouse.dart
+++ b/lib/src/webdriver/webdriver_mouse.dart
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:core';
 
 import 'package:pageloader/pageloader.dart';

--- a/lib/src/webdriver/webdriver_page_loader_element.dart
+++ b/lib/src/webdriver/webdriver_page_loader_element.dart
@@ -350,7 +350,6 @@ class WebDriverPageLoaderElement implements PageLoaderElement {
       await scrollIntoViewCentered();
       _retryWhenStale<void>(() => _single.click());
     }
-    _retryWhenStale<void>(() => _single.click());
   }
 
   @override

--- a/lib/src/webdriver/webdriver_pointer.dart
+++ b/lib/src/webdriver/webdriver_pointer.dart
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:core';
 
 import 'package:pageloader/pageloader.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,10 +14,10 @@ description:
 homepage: https://github.com/google/pageloader
 
 environment:
-  sdk: '>=2.3.0 <2.12.0'
+  sdk: '>=2.7.0 <2.12.0'
 
 dependencies:
-  analyzer: '>=0.36.0 <0.41.1'
+  analyzer: '>=0.39.16 <0.41.1'
   build: '>0.12.7 <1.6.0'
   built_value: ^7.1.0
   build_config: '>=0.3.1 <0.4.7'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   sdk: '>=2.7.0 <2.12.0'
 
 dependencies:
-  analyzer: '>=0.39.16 <1.0.0'
+  analyzer: '>=0.39.14 <1.0.0'
   build: '>=1.3.0 <2.0.0'
   built_value: ^7.1.0
   build_config: '>=0.3.1 <0.4.7'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   matcher: ^0.12.0+1
   quiver: '>=2.0.0 <3.0.0'
   source_gen: '>=0.9.6 <1.0.0'
-  webdriver: ^2.1.0
+  webdriver: ^2.1.2
 
 dev_dependencies:
   build_runner: '>=1.10.1 <2.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pageloader
 
-version: 3.3.1
+version: 3.3.2
 
 authors:
   - Marc Fisher II (emeritus)
@@ -14,13 +14,14 @@ description:
 homepage: https://github.com/google/pageloader
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.3.0 <2.12.0'
 
 dependencies:
-  analyzer: '>=0.36.0 <0.40.0'
-  build: '>0.12.7 <2.0.0'
-  built_value: ^7.0.0
-  build_config: '>=0.3.1 <5.0.0'
+  analyzer: '>=0.36.0 <0.41.1'
+  build: '>0.12.7 <1.6.0'
+  built_value: ^7.1.0
+  build_config: '>=0.3.1 <0.4.7'
+  js: '>=0.6.0 <0.6.3'
   matcher: ^0.12.0+1
   quiver: '>=2.0.0 <3.0.0'
   source_gen: ^0.9.1+3
@@ -29,5 +30,5 @@ dependencies:
 dev_dependencies:
   build_runner: ^1.6.0
   built_value_generator: ^7.0.0
-  path: ^1.3.6
-  test: ^1.2.0
+  path: '>=1.3.6 <1.8.0'
+  test: '>=1.2.0 <1.16.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   webdriver: ^2.1.0
 
 dev_dependencies:
-  build_runner: '>=1.7.0 <2.0.0'
+  build_runner: '>=1.10.1 <2.0.0'
   built_value_generator: ^7.1.0
   path: '>=1.3.6 <1.8.0'
   test: '>=1.2.0 <1.16.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,18 +17,18 @@ environment:
   sdk: '>=2.7.0 <2.12.0'
 
 dependencies:
-  analyzer: '>=0.39.16 <0.41.1'
-  build: '>0.12.7 <1.6.0'
+  analyzer: '>=0.39.16 <1.0.0'
+  build: '>=1.3.0 <2.0.0'
   built_value: ^7.1.0
   build_config: '>=0.3.1 <0.4.7'
   js: '>=0.6.0 <0.6.3'
   matcher: ^0.12.0+1
   quiver: '>=2.0.0 <3.0.0'
-  source_gen: ^0.9.1+3
+  source_gen: '>=0.9.6 <1.0.0'
   webdriver: ^2.1.0
 
 dev_dependencies:
-  build_runner: ^1.6.0
-  built_value_generator: ^7.0.0
+  build_runner: '>=1.7.0 <2.0.0'
+  built_value_generator: ^7.1.0
   path: '>=1.3.6 <1.8.0'
   test: '>=1.2.0 <1.16.0'

--- a/test/data/html_setup.dart
+++ b/test/data/html_setup.dart
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:html' as html;
 import 'dart:svg' show SvgElement;
 
@@ -134,12 +133,13 @@ html.Element setUp() {
   }
   div.setInnerHtml(bodyHtml, validator: NoOpNodeValidator());
 
-  html.document.getElementsByTagName('a-custom-tag').forEach((element) {
-    if (element is html.Element) {
-      final shadow = element.createShadowRoot();
-      shadow.setInnerHtml(templateHtml, validator: NoOpNodeValidator());
-    }
-  });
+  // TODO: Investigate what the root cause of this issue.
+  // html.document.getElementsByTagName('a-custom-tag').forEach((element) {
+  //   if (element is html.Element) {
+  //     final shadow = element.createShadowRoot();
+  //     shadow.setInnerHtml(templateHtml, validator: NoOpNodeValidator());
+  //   }
+  // });
 
   // Get all mouseevent driven div elements and bind them
   final displayedMouseDiv = html.document.getElementById('mouse');
@@ -181,15 +181,24 @@ void bindKeyboardListener(html.Element element) {
     if (evt.keyCode == 13) {
       element.text += ' enter keydown;';
     }
+    if (evt.key == 'Enter') {
+      element.text += ' (Enter key value);';
+    }
   });
   element.onKeyPress.listen((evt) {
     if (evt.keyCode == 13) {
       element.text += ' enter keypress;';
     }
+    if (evt.key == 'Enter') {
+      element.text += ' (Enter key value);';
+    }
   });
   element.onKeyUp.listen((evt) {
     if (evt.keyCode == 13) {
       element.text += ' enter keyup;';
+    }
+    if (evt.key == 'Enter') {
+      element.text += ' (Enter key value);';
     }
   });
 }

--- a/test/data/long_html_setup.dart
+++ b/test/data/long_html_setup.dart
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:html' as html;
 
 import 'package:pageloader/html.dart';

--- a/test/examples/correct/class_checks.g.dart
+++ b/test/examples/correct/class_checks.g.dart
@@ -6,15 +6,12 @@ part of 'class_checks.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$ChecksMixin on ChecksMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInChecksMixin() {
     return {};
@@ -65,7 +62,6 @@ mixin $$ChecksMixin on ChecksMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -141,8 +137,6 @@ class $ClassChecks extends ClassChecks with $$ClassChecks {
 
 mixin $$ClassChecks on ClassChecks {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInClassChecks() {
     return {};
@@ -193,7 +187,6 @@ mixin $$ClassChecks on ClassChecks {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -270,8 +263,6 @@ class $EnsureTagChecks extends EnsureTagChecks with $$EnsureTagChecks {
 
 mixin $$EnsureTagChecks on EnsureTagChecks {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInEnsureTagChecks() {
     return {};
@@ -322,7 +313,6 @@ mixin $$EnsureTagChecks on EnsureTagChecks {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -414,8 +404,6 @@ class $ClassChecksUsingClassMixin extends ClassChecksUsingClassMixin
 
 mixin $$ClassChecksUsingClassMixin on ClassChecksUsingClassMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInClassChecksUsingClassMixin() {
     return {};
@@ -442,7 +430,6 @@ mixin $$ClassChecksUsingClassMixin on ClassChecksUsingClassMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -532,8 +519,6 @@ class $ClassChecksUsingMixin extends ClassChecksUsingMixin
 
 mixin $$ClassChecksUsingMixin on ClassChecksUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInClassChecksUsingMixin() {
     return {};
@@ -560,7 +545,6 @@ mixin $$ClassChecksUsingMixin on ClassChecksUsingMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -652,8 +636,6 @@ class $EnsureTagChecksUsingMixin extends EnsureTagChecksUsingMixin
 
 mixin $$EnsureTagChecksUsingMixin on EnsureTagChecksUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInEnsureTagChecksUsingMixin() {
     return {};
@@ -680,15 +662,12 @@ mixin $$EnsureTagChecksUsingMixin on EnsureTagChecksUsingMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$ChecksClassMixin on ChecksClassMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInChecksClassMixin() {
     return {};

--- a/test/examples/correct/empty.g.dart
+++ b/test/examples/correct/empty.g.dart
@@ -6,7 +6,6 @@ part of 'empty.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -84,8 +83,6 @@ class $Empty extends Empty with $$Empty {
 
 mixin $$Empty on Empty {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInEmpty() {
     return {};
@@ -111,15 +108,12 @@ mixin $$Empty on Empty {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$EmptyMixin on EmptyMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInEmptyMixin() {
     return {};

--- a/test/examples/correct/finders.g.dart
+++ b/test/examples/correct/finders.g.dart
@@ -6,7 +6,6 @@ part of 'finders.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -96,8 +95,6 @@ class $Finders extends Finders with $$Finders {
 
 mixin $$Finders on Finders {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInFinders() {
     return {};
@@ -140,7 +137,8 @@ mixin $$Finders on Finders {
     }
     try {
       var checkTagPOElement = this.checkTagPO as dynamic;
-      var checkTagPOIndex = internalIds.indexOf(checkTagPOElement.$__root__.id);
+      var checkTagPOIndex =
+          internalIds.indexOf(checkTagPOElement.$__root__.id as String);
       if (checkTagPOIndex >= 0 && checkTagPOIndex < closestIndex) {
         closestIndex = checkTagPOIndex;
         closestValue = (ids) =>
@@ -183,7 +181,6 @@ mixin $$Finders on Finders {
     return {closestIndex: closestValue};
   }
 
-  PageLoaderElement get secret;
   PageLoaderElement get _secret {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('Finders', '_secret');
@@ -234,7 +231,6 @@ mixin $$Finders on Finders {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -321,8 +317,6 @@ class $CheckTagPO extends CheckTagPO with $$CheckTagPO {
 
 mixin $$CheckTagPO on CheckTagPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInCheckTagPO() {
     return {};
@@ -373,7 +367,6 @@ mixin $$CheckTagPO on CheckTagPO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -465,8 +458,6 @@ class $FindersUsingMixin extends FindersUsingMixin
 
 mixin $$FindersUsingMixin on FindersUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInFindersUsingMixin() {
     return {};
@@ -493,15 +484,12 @@ mixin $$FindersUsingMixin on FindersUsingMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$FindersMixin on FindersMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInFindersMixin() {
     return {};
@@ -544,7 +532,8 @@ mixin $$FindersMixin on FindersMixin {
     }
     try {
       var checkTagPOElement = this.checkTagPO as dynamic;
-      var checkTagPOIndex = internalIds.indexOf(checkTagPOElement.$__root__.id);
+      var checkTagPOIndex =
+          internalIds.indexOf(checkTagPOElement.$__root__.id as String);
       if (checkTagPOIndex >= 0 && checkTagPOIndex < closestIndex) {
         closestIndex = checkTagPOIndex;
         closestValue = (ids) =>
@@ -587,7 +576,6 @@ mixin $$FindersMixin on FindersMixin {
     return {closestIndex: closestValue};
   }
 
-  PageLoaderElement get secret;
   PageLoaderElement get _secret {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('FindersMixin', '_secret');

--- a/test/examples/correct/generics.g.dart
+++ b/test/examples/correct/generics.g.dart
@@ -6,7 +6,6 @@ part of 'generics.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -107,8 +106,6 @@ class $Generics<T> extends Generics<T> with $$Generics<T> {
 
 mixin $$Generics<T> on Generics<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInGenerics() {
     return {};
@@ -141,7 +138,6 @@ mixin $$Generics<T> on Generics<T> {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -228,8 +224,6 @@ class $CheckedGenerics<T> extends CheckedGenerics<T> with $$CheckedGenerics<T> {
 
 mixin $$CheckedGenerics<T> on CheckedGenerics<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInCheckedGenerics() {
     return {};
@@ -259,7 +253,6 @@ mixin $$CheckedGenerics<T> on CheckedGenerics<T> {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -349,8 +342,6 @@ class $GenericPair<T, V> extends GenericPair<T, V> with $$GenericPair<T, V> {
 
 mixin $$GenericPair<T, V> on GenericPair<T, V> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInGenericPair() {
     return {};
@@ -380,7 +371,6 @@ mixin $$GenericPair<T, V> on GenericPair<T, V> {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -459,8 +449,6 @@ class $RootPo<T> extends RootPo<T> with $$RootPo<T> {
 
 mixin $$RootPo<T> on RootPo<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInRootPo() {
     return {};
@@ -496,7 +484,8 @@ mixin $$RootPo<T> on RootPo<T> {
     String Function(List<String>) closestValue;
     try {
       var genericsElement = this.generics as dynamic;
-      var genericsIndex = internalIds.indexOf(genericsElement.$__root__.id);
+      var genericsIndex =
+          internalIds.indexOf(genericsElement.$__root__.id as String);
       if (genericsIndex >= 0 && genericsIndex < closestIndex) {
         closestIndex = genericsIndex;
         closestValue = (ids) =>
@@ -509,7 +498,7 @@ mixin $$RootPo<T> on RootPo<T> {
     try {
       var checkedGenericsElement = this.checkedGenerics as dynamic;
       var checkedGenericsIndex =
-          internalIds.indexOf(checkedGenericsElement.$__root__.id);
+          internalIds.indexOf(checkedGenericsElement.$__root__.id as String);
       if (checkedGenericsIndex >= 0 && checkedGenericsIndex < closestIndex) {
         closestIndex = checkedGenericsIndex;
         closestValue = (ids) =>
@@ -526,7 +515,7 @@ mixin $$RootPo<T> on RootPo<T> {
       try {
         var genericsListElement = genericsListElements[elementIter] as dynamic;
         var genericsListIndex =
-            internalIds.indexOf(genericsListElement.$__root__.id);
+            internalIds.indexOf(genericsListElement.$__root__.id as String);
         if (genericsListIndex >= 0 && genericsListIndex < closestIndex) {
           closestIndex = genericsListIndex;
           closestValue = (ids) =>
@@ -544,8 +533,8 @@ mixin $$RootPo<T> on RootPo<T> {
       try {
         var checkedGenericsListElement =
             checkedGenericsListElements[elementIter] as dynamic;
-        var checkedGenericsListIndex =
-            internalIds.indexOf(checkedGenericsListElement.$__root__.id);
+        var checkedGenericsListIndex = internalIds
+            .indexOf(checkedGenericsListElement.$__root__.id as String);
         if (checkedGenericsListIndex >= 0 &&
             checkedGenericsListIndex < closestIndex) {
           closestIndex = checkedGenericsListIndex;
@@ -612,7 +601,6 @@ mixin $$RootPo<T> on RootPo<T> {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -704,8 +692,6 @@ class $GenericsUsingMixin<T> extends GenericsUsingMixin<T>
 
 mixin $$GenericsUsingMixin<T> on GenericsUsingMixin<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInGenericsUsingMixin() {
     return {};
@@ -732,15 +718,12 @@ mixin $$GenericsUsingMixin<T> on GenericsUsingMixin<T> {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$GenericsMixin<T> on GenericsMixin<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInGenericsMixin() {
     return {};
@@ -773,7 +756,6 @@ mixin $$GenericsMixin<T> on GenericsMixin<T> {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -866,8 +848,6 @@ class $GenericPairUsingMixin<T, V> extends GenericPairUsingMixin<T, V>
 
 mixin $$GenericPairUsingMixin<T, V> on GenericPairUsingMixin<T, V> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInGenericPairUsingMixin() {
     return {};
@@ -894,15 +874,12 @@ mixin $$GenericPairUsingMixin<T, V> on GenericPairUsingMixin<T, V> {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$GenericPairMixin<T, V> on GenericPairMixin<T, V> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInGenericPairMixin() {
     return {};
@@ -933,7 +910,6 @@ mixin $$GenericPairMixin<T, V> on GenericPairMixin<T, V> {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -1025,8 +1001,6 @@ class $RootPoUsingMixin<T> extends RootPoUsingMixin<T>
 
 mixin $$RootPoUsingMixin<T> on RootPoUsingMixin<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInRootPoUsingMixin() {
     return {};
@@ -1053,15 +1027,12 @@ mixin $$RootPoUsingMixin<T> on RootPoUsingMixin<T> {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$RootPoMixin<T> on RootPoMixin<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInRootPoMixin() {
     return {};
@@ -1097,7 +1068,8 @@ mixin $$RootPoMixin<T> on RootPoMixin<T> {
     String Function(List<String>) closestValue;
     try {
       var genericsElement = this.generics as dynamic;
-      var genericsIndex = internalIds.indexOf(genericsElement.$__root__.id);
+      var genericsIndex =
+          internalIds.indexOf(genericsElement.$__root__.id as String);
       if (genericsIndex >= 0 && genericsIndex < closestIndex) {
         closestIndex = genericsIndex;
         closestValue = (ids) =>
@@ -1110,7 +1082,7 @@ mixin $$RootPoMixin<T> on RootPoMixin<T> {
     try {
       var checkedGenericsElement = this.checkedGenerics as dynamic;
       var checkedGenericsIndex =
-          internalIds.indexOf(checkedGenericsElement.$__root__.id);
+          internalIds.indexOf(checkedGenericsElement.$__root__.id as String);
       if (checkedGenericsIndex >= 0 && checkedGenericsIndex < closestIndex) {
         closestIndex = checkedGenericsIndex;
         closestValue = (ids) =>
@@ -1127,7 +1099,7 @@ mixin $$RootPoMixin<T> on RootPoMixin<T> {
       try {
         var genericsListElement = genericsListElements[elementIter] as dynamic;
         var genericsListIndex =
-            internalIds.indexOf(genericsListElement.$__root__.id);
+            internalIds.indexOf(genericsListElement.$__root__.id as String);
         if (genericsListIndex >= 0 && genericsListIndex < closestIndex) {
           closestIndex = genericsListIndex;
           closestValue = (ids) =>
@@ -1145,8 +1117,8 @@ mixin $$RootPoMixin<T> on RootPoMixin<T> {
       try {
         var checkedGenericsListElement =
             checkedGenericsListElements[elementIter] as dynamic;
-        var checkedGenericsListIndex =
-            internalIds.indexOf(checkedGenericsListElement.$__root__.id);
+        var checkedGenericsListIndex = internalIds
+            .indexOf(checkedGenericsListElement.$__root__.id as String);
         if (checkedGenericsListIndex >= 0 &&
             checkedGenericsListIndex < closestIndex) {
           closestIndex = checkedGenericsListIndex;

--- a/test/examples/correct/iterables.g.dart
+++ b/test/examples/correct/iterables.g.dart
@@ -6,7 +6,6 @@ part of 'iterables.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -85,8 +84,6 @@ class $Iterables extends Iterables with $$Iterables {
 
 mixin $$Iterables on Iterables {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInIterables() {
     return {};
@@ -160,7 +157,6 @@ mixin $$Iterables on Iterables {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -239,8 +235,6 @@ class $InnerObject extends InnerObject with $$InnerObject {
 
 mixin $$InnerObject on InnerObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInInnerObject() {
     return {};
@@ -323,7 +317,6 @@ mixin $$InnerObject on InnerObject {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -415,8 +408,6 @@ class $IterablesUsingMixin extends IterablesUsingMixin
 
 mixin $$IterablesUsingMixin on IterablesUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInIterablesUsingMixin() {
     return {};
@@ -443,15 +434,12 @@ mixin $$IterablesUsingMixin on IterablesUsingMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$IterablesMixin on IterablesMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInIterablesMixin() {
     return {};
@@ -525,7 +513,6 @@ mixin $$IterablesMixin on IterablesMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -618,8 +605,6 @@ class $InnerObjectUsingMixin extends InnerObjectUsingMixin
 
 mixin $$InnerObjectUsingMixin on InnerObjectUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInInnerObjectUsingMixin() {
     return {};
@@ -646,15 +631,12 @@ mixin $$InnerObjectUsingMixin on InnerObjectUsingMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$InnerObjectMixin on InnerObjectMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInInnerObjectMixin() {
     return {};

--- a/test/examples/correct/list.dart
+++ b/test/examples/correct/list.dart
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'package:pageloader/pageloader.dart';
 
 import 'finders.dart' show CheckTagPO;

--- a/test/examples/correct/list.g.dart
+++ b/test/examples/correct/list.g.dart
@@ -6,7 +6,6 @@ part of 'list.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -84,8 +83,6 @@ class $Lists extends Lists with $$Lists {
 
 mixin $$Lists on Lists {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInLists() {
     return {};
@@ -132,7 +129,7 @@ mixin $$Lists on Lists {
       try {
         var nestedSyncElement = nestedSyncElements[elementIter] as dynamic;
         var nestedSyncIndex =
-            internalIds.indexOf(nestedSyncElement.$__root__.id);
+            internalIds.indexOf(nestedSyncElement.$__root__.id as String);
         if (nestedSyncIndex >= 0 && nestedSyncIndex < closestIndex) {
           closestIndex = nestedSyncIndex;
           closestValue = (ids) =>
@@ -151,7 +148,7 @@ mixin $$Lists on Lists {
         var checkTagPOSyncElement =
             checkTagPOSyncElements[elementIter] as dynamic;
         var checkTagPOSyncIndex =
-            internalIds.indexOf(checkTagPOSyncElement.$__root__.id);
+            internalIds.indexOf(checkTagPOSyncElement.$__root__.id as String);
         if (checkTagPOSyncIndex >= 0 && checkTagPOSyncIndex < closestIndex) {
           closestIndex = checkTagPOSyncIndex;
           closestValue = (ids) =>
@@ -260,7 +257,6 @@ mixin $$Lists on Lists {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -339,8 +335,6 @@ class $InnerListObject extends InnerListObject with $$InnerListObject {
 
 mixin $$InnerListObject on InnerListObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInInnerListObject() {
     return {};
@@ -407,7 +401,6 @@ mixin $$InnerListObject on InnerListObject {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -499,8 +492,6 @@ class $ListsUsingMixin extends ListsUsingMixin
 
 mixin $$ListsUsingMixin on ListsUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInListsUsingMixin() {
     return {};
@@ -526,15 +517,12 @@ mixin $$ListsUsingMixin on ListsUsingMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$ListsMixin on ListsMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInListsMixin() {
     return {};
@@ -581,7 +569,7 @@ mixin $$ListsMixin on ListsMixin {
       try {
         var nestedSyncElement = nestedSyncElements[elementIter] as dynamic;
         var nestedSyncIndex =
-            internalIds.indexOf(nestedSyncElement.$__root__.id);
+            internalIds.indexOf(nestedSyncElement.$__root__.id as String);
         if (nestedSyncIndex >= 0 && nestedSyncIndex < closestIndex) {
           closestIndex = nestedSyncIndex;
           closestValue = (ids) =>
@@ -600,7 +588,7 @@ mixin $$ListsMixin on ListsMixin {
         var checkTagPOSyncElement =
             checkTagPOSyncElements[elementIter] as dynamic;
         var checkTagPOSyncIndex =
-            internalIds.indexOf(checkTagPOSyncElement.$__root__.id);
+            internalIds.indexOf(checkTagPOSyncElement.$__root__.id as String);
         if (checkTagPOSyncIndex >= 0 && checkTagPOSyncIndex < closestIndex) {
           closestIndex = checkTagPOSyncIndex;
           closestValue = (ids) =>
@@ -709,7 +697,6 @@ mixin $$ListsMixin on ListsMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -803,8 +790,6 @@ class $InnerListObjectUsingMixin extends InnerListObjectUsingMixin
 
 mixin $$InnerListObjectUsingMixin on InnerListObjectUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInInnerListObjectUsingMixin() {
     return {};
@@ -831,15 +816,12 @@ mixin $$InnerListObjectUsingMixin on InnerListObjectUsingMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$InnerListObjectMixin on InnerListObjectMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInInnerListObjectMixin() {
     return {};

--- a/test/examples/correct/mouse.g.dart
+++ b/test/examples/correct/mouse.g.dart
@@ -6,7 +6,6 @@ part of 'mouse.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -86,7 +85,6 @@ class $MouseObject extends MouseObject with $$MouseObject {
 mixin $$MouseObject on MouseObject {
   PageLoaderElement $__root__;
   PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInMouseObject() {
     return {};
@@ -124,7 +122,6 @@ mixin $$MouseObject on MouseObject {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -217,8 +214,6 @@ class $MouseObjectUsingMixin extends MouseObjectUsingMixin
 
 mixin $$MouseObjectUsingMixin on MouseObjectUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInMouseObjectUsingMixin() {
     return {};
@@ -245,7 +240,6 @@ mixin $$MouseObjectUsingMixin on MouseObjectUsingMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -253,7 +247,6 @@ mixin $$MouseObjectUsingMixin on MouseObjectUsingMixin {
 mixin $$MouseObjectMixin on MouseObjectMixin {
   PageLoaderElement $__root__;
   PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInMouseObjectMixin() {
     return {};

--- a/test/examples/correct/multiple_in_file.g.dart
+++ b/test/examples/correct/multiple_in_file.g.dart
@@ -6,7 +6,6 @@ part of 'multiple_in_file.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -84,8 +83,6 @@ class $A extends A with $$A {
 
 mixin $$A on A {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInA() {
     return {};
@@ -111,7 +108,7 @@ mixin $$A on A {
     String Function(List<String>) closestValue;
     try {
       var bElement = this.b as dynamic;
-      var bIndex = internalIds.indexOf(bElement.$__root__.id);
+      var bIndex = internalIds.indexOf(bElement.$__root__.id as String);
       if (bIndex >= 0 && bIndex < closestIndex) {
         closestIndex = bIndex;
         closestValue = (ids) => 'b.${bElement.findChain(ids, action)}'
@@ -136,7 +133,6 @@ mixin $$A on A {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -214,8 +210,6 @@ class $B extends B with $$B {
 
 mixin $$B on B {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInB() {
     return {};
@@ -265,7 +259,6 @@ mixin $$B on B {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -343,8 +336,6 @@ class $C extends C with $$C {
 
 mixin $$C on C {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInC() {
     return {};
@@ -370,7 +361,7 @@ mixin $$C on C {
     String Function(List<String>) closestValue;
     try {
       var bElement = this.b as dynamic;
-      var bIndex = internalIds.indexOf(bElement.$__root__.id);
+      var bIndex = internalIds.indexOf(bElement.$__root__.id as String);
       if (bIndex >= 0 && bIndex < closestIndex) {
         closestIndex = bIndex;
         closestValue = (ids) => 'b.${bElement.findChain(ids, action)}'

--- a/test/examples/correct/nested.g.dart
+++ b/test/examples/correct/nested.g.dart
@@ -6,7 +6,6 @@ part of 'nested.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -85,8 +84,6 @@ class $Nested extends Nested with $$Nested {
 
 mixin $$Nested on Nested {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInNested() {
     return {};
@@ -114,7 +111,7 @@ mixin $$Nested on Nested {
     try {
       var findersElementElement = this.findersElement as dynamic;
       var findersElementIndex =
-          internalIds.indexOf(findersElementElement.$__root__.id);
+          internalIds.indexOf(findersElementElement.$__root__.id as String);
       if (findersElementIndex >= 0 && findersElementIndex < closestIndex) {
         closestIndex = findersElementIndex;
         closestValue = (ids) =>
@@ -140,7 +137,6 @@ mixin $$Nested on Nested {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -232,8 +228,6 @@ class $NestedUsingMixin extends NestedUsingMixin
 
 mixin $$NestedUsingMixin on NestedUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInNestedUsingMixin() {
     return {};
@@ -260,15 +254,12 @@ mixin $$NestedUsingMixin on NestedUsingMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$NestedMixin on NestedMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInNestedMixin() {
     return {};
@@ -296,7 +287,7 @@ mixin $$NestedMixin on NestedMixin {
     try {
       var findersElementElement = this.findersElement as dynamic;
       var findersElementIndex =
-          internalIds.indexOf(findersElementElement.$__root__.id);
+          internalIds.indexOf(findersElementElement.$__root__.id as String);
       if (findersElementIndex >= 0 && findersElementIndex < closestIndex) {
         closestIndex = findersElementIndex;
         closestValue = (ids) =>

--- a/test/examples/correct/null_element.g.dart
+++ b/test/examples/correct/null_element.g.dart
@@ -6,7 +6,6 @@ part of 'null_element.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -85,8 +84,6 @@ class $ParentRoot extends ParentRoot with $$ParentRoot {
 
 mixin $$ParentRoot on ParentRoot {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInParentRoot() {
     return {};
@@ -113,7 +110,8 @@ mixin $$ParentRoot on ParentRoot {
     String Function(List<String>) closestValue;
     try {
       var _nullPOElement = this._nullPO as dynamic;
-      var _nullPOIndex = internalIds.indexOf(_nullPOElement.$__root__.id);
+      var _nullPOIndex =
+          internalIds.indexOf(_nullPOElement.$__root__.id as String);
       if (_nullPOIndex >= 0 && _nullPOIndex < closestIndex) {
         closestIndex = _nullPOIndex;
         closestValue = (ids) =>
@@ -125,7 +123,7 @@ mixin $$ParentRoot on ParentRoot {
     }
     try {
       var gensElement = this.gens as dynamic;
-      var gensIndex = internalIds.indexOf(gensElement.$__root__.id);
+      var gensIndex = internalIds.indexOf(gensElement.$__root__.id as String);
       if (gensIndex >= 0 && gensIndex < closestIndex) {
         closestIndex = gensIndex;
         closestValue = (ids) => 'gens.${gensElement.findChain(ids, action)}'
@@ -184,7 +182,6 @@ mixin $$ParentRoot on ParentRoot {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -263,8 +260,6 @@ class $NullPO extends NullPO with $$NullPO {
 
 mixin $$NullPO on NullPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInNullPO() {
     return {};
@@ -290,7 +285,6 @@ mixin $$NullPO on NullPO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -369,8 +363,6 @@ class $Generics<T> extends Generics<T> with $$Generics<T> {
 
 mixin $$Generics<T> on Generics<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInGenerics() {
     return {};

--- a/test/examples/correct/parameters.g.dart
+++ b/test/examples/correct/parameters.g.dart
@@ -6,7 +6,6 @@ part of 'parameters.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -139,8 +138,6 @@ class $Parameters extends Parameters with $$Parameters {
 
 mixin $$Parameters on Parameters {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInParameters() {
     return {};
@@ -182,7 +179,6 @@ mixin $$Parameters on Parameters {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -275,8 +271,6 @@ class $ParametersUsingMixin extends ParametersUsingMixin
 
 mixin $$ParametersUsingMixin on ParametersUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInParametersUsingMixin() {
     return {};
@@ -303,15 +297,12 @@ mixin $$ParametersUsingMixin on ParametersUsingMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$ParametersMixin on ParametersMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInParametersMixin() {
     return {};

--- a/test/examples/correct/root.g.dart
+++ b/test/examples/correct/root.g.dart
@@ -6,7 +6,6 @@ part of 'root.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -85,8 +84,6 @@ class $ParentRoot extends ParentRoot with $$ParentRoot {
 
 mixin $$ParentRoot on ParentRoot {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInParentRoot() {
     return {};
@@ -113,7 +110,7 @@ mixin $$ParentRoot on ParentRoot {
     String Function(List<String>) closestValue;
     try {
       var rootElement = this.root as dynamic;
-      var rootIndex = internalIds.indexOf(rootElement.$__root__.id);
+      var rootIndex = internalIds.indexOf(rootElement.$__root__.id as String);
       if (rootIndex >= 0 && rootIndex < closestIndex) {
         closestIndex = rootIndex;
         closestValue = (ids) => 'root.${rootElement.findChain(ids, action)}'
@@ -138,7 +135,6 @@ mixin $$ParentRoot on ParentRoot {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -216,8 +212,6 @@ class $Root extends Root with $$Root {
 
 mixin $$Root on Root {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInRoot() {
     return {};
@@ -293,7 +287,6 @@ mixin $$Root on Root {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -386,8 +379,6 @@ class $ParentRootUsingMixin extends ParentRootUsingMixin
 
 mixin $$ParentRootUsingMixin on ParentRootUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInParentRootUsingMixin() {
     return {};
@@ -414,15 +405,12 @@ mixin $$ParentRootUsingMixin on ParentRootUsingMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$ParentRootMixin on ParentRootMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInParentRootMixin() {
     return {};
@@ -449,7 +437,7 @@ mixin $$ParentRootMixin on ParentRootMixin {
     String Function(List<String>) closestValue;
     try {
       var rootElement = this.root as dynamic;
-      var rootIndex = internalIds.indexOf(rootElement.$__root__.id);
+      var rootIndex = internalIds.indexOf(rootElement.$__root__.id as String);
       if (rootIndex >= 0 && rootIndex < closestIndex) {
         closestIndex = rootIndex;
         closestValue = (ids) => 'root.${rootElement.findChain(ids, action)}'
@@ -474,7 +462,6 @@ mixin $$ParentRootMixin on ParentRootMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -566,8 +553,6 @@ class $RootUsingMixin extends RootUsingMixin
 
 mixin $$RootUsingMixin on RootUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInRootUsingMixin() {
     return {};
@@ -593,15 +578,12 @@ mixin $$RootUsingMixin on RootUsingMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$RootMixin on RootMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInRootMixin() {
     return {};

--- a/test/examples/correct/unannotated.g.dart
+++ b/test/examples/correct/unannotated.g.dart
@@ -6,7 +6,6 @@ part of 'unannotated.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -91,13 +90,13 @@ class $Unannotated extends Unannotated with $$Unannotated {
     return returnMe;
   }
 
-  set myField(bool setValue) {
+  set bool(bool setValue) {
     for (final __listener in $__root__.listeners) {
-      __listener.startPageObjectMethod('Unannotated', 'myField');
+      __listener.startPageObjectMethod('Unannotated', 'bool');
     }
-    super.myField = setValue;
+    super.bool = setValue;
     for (final __listener in $__root__.listeners) {
-      __listener.endPageObjectMethod('Unannotated', 'myField');
+      __listener.endPageObjectMethod('Unannotated', 'bool');
     }
     return;
   }
@@ -184,8 +183,6 @@ class $Unannotated extends Unannotated with $$Unannotated {
 
 mixin $$Unannotated on Unannotated {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInUnannotated() {
     return {
@@ -234,12 +231,8 @@ mixin $$Unannotated on Unannotated {
     String Function(List<String>) closestValue;
     return {closestIndex: closestValue};
   }
-
-  bool get isFieldSet;
-  set myField(bool setValue);
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -332,8 +325,6 @@ class $UnannotatedUsingMixin extends UnannotatedUsingMixin
 
 mixin $$UnannotatedUsingMixin on UnannotatedUsingMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInUnannotatedUsingMixin() {
     return {};
@@ -360,15 +351,12 @@ mixin $$UnannotatedUsingMixin on UnannotatedUsingMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$UnannotatedMixin on UnannotatedMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInUnannotatedMixin() {
     return {
@@ -418,7 +406,4 @@ mixin $$UnannotatedMixin on UnannotatedMixin {
     String Function(List<String>) closestValue;
     return {closestIndex: closestValue};
   }
-
-  bool get isFieldSet;
-  set myField(bool setValue);
 }

--- a/test/examples/correct/unannotated.g.dart
+++ b/test/examples/correct/unannotated.g.dart
@@ -90,13 +90,13 @@ class $Unannotated extends Unannotated with $$Unannotated {
     return returnMe;
   }
 
-  set bool(bool setValue) {
+  set myField(bool setValue) {
     for (final __listener in $__root__.listeners) {
-      __listener.startPageObjectMethod('Unannotated', 'bool');
+      __listener.startPageObjectMethod('Unannotated', 'myField');
     }
-    super.bool = setValue;
+    super.myField = setValue;
     for (final __listener in $__root__.listeners) {
-      __listener.endPageObjectMethod('Unannotated', 'bool');
+      __listener.endPageObjectMethod('Unannotated', 'myField');
     }
     return;
   }

--- a/test/generation_test_setup/dummy_page_loader_element.dart
+++ b/test/generation_test_setup/dummy_page_loader_element.dart
@@ -11,12 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:core';
 import 'dart:math';
 
 import 'package:pageloader/pageloader.dart';
-import 'package:quiver/collection.dart';
 
 /// Concrete implementations for use in code generation tests, mostly via
 /// toString().
@@ -203,6 +201,9 @@ class DummyPageLoaderElement implements PageLoaderElement {
   String get innerText => throw 'not implemented';
 
   @override
+  List<PageLoaderElement> get shadowRootChildren => throw 'not implemented';
+
+  @override
   String get visibleText => throw 'not implemented';
 
   @override
@@ -292,8 +293,11 @@ class DummyPageLoaderElement implements PageLoaderElement {
   String testCreatorMethods() => throw 'not implemented';
 }
 
-class DummyPageLoaderAttributes extends DelegatingMap<String, String>
-    implements PageLoaderAttributes {
+class DummyPageLoaderAttributes implements PageLoaderAttributes {
+  final _map = <String, String>{};
+
   @override
-  final delegate = <String, String>{};
+  String operator [](String name) => _map[name];
+
+  void operator []=(String name, String value) => _map[name] = value;
 }

--- a/test/setup/webdriver_environment.dart
+++ b/test/setup/webdriver_environment.dart
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
 import 'package:pageloader/webdriver.dart';
 import 'package:webdriver/sync_io.dart';
 

--- a/test/src/annotations.dart
+++ b/test/src/annotations.dart
@@ -42,7 +42,9 @@ void runTests(GetNewContext contextGenerator) {
         fail('Expected to throw on bad @CheckTag');
       } catch (e) {
         expect(
-            e.toString(), contains('Failed check: @CheckTag("inconceivable")'));
+            e.toString(),
+            contains('Failed check: @CheckTag("inconceivable"). '
+                'Found "table" instead.'));
       }
     });
 
@@ -109,7 +111,9 @@ void runTests(GetNewContext contextGenerator) {
         fail('Expected to throw on bad @CheckTag');
       } catch (e) {
         expect(
-            e.toString(), contains('Failed check: @CheckTag("inconceivable")'));
+            e.toString(),
+            contains('Failed check: @CheckTag("inconceivable"). '
+                'Found "table" instead.'));
       }
     });
 

--- a/test/src/annotations.g.dart
+++ b/test/src/annotations.g.dart
@@ -6,7 +6,6 @@ part of 'annotations.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -85,8 +84,6 @@ class $BaseObject extends BaseObject with $$BaseObject {
 
 mixin $$BaseObject on BaseObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInBaseObject() {
     return {};
@@ -122,7 +119,7 @@ mixin $$BaseObject on BaseObject {
     String Function(List<String>) closestValue;
     try {
       var tableElement = this.table as dynamic;
-      var tableIndex = internalIds.indexOf(tableElement.$__root__.id);
+      var tableIndex = internalIds.indexOf(tableElement.$__root__.id as String);
       if (tableIndex >= 0 && tableIndex < closestIndex) {
         closestIndex = tableIndex;
         closestValue = (ids) => 'table.${tableElement.findChain(ids, action)}'
@@ -133,8 +130,8 @@ mixin $$BaseObject on BaseObject {
     }
     try {
       var tableUsingCheckedTagElement = this.tableUsingCheckedTag as dynamic;
-      var tableUsingCheckedTagIndex =
-          internalIds.indexOf(tableUsingCheckedTagElement.$__root__.id);
+      var tableUsingCheckedTagIndex = internalIds
+          .indexOf(tableUsingCheckedTagElement.$__root__.id as String);
       if (tableUsingCheckedTagIndex >= 0 &&
           tableUsingCheckedTagIndex < closestIndex) {
         closestIndex = tableUsingCheckedTagIndex;
@@ -147,7 +144,8 @@ mixin $$BaseObject on BaseObject {
     }
     try {
       var badTableElement = this.badTable as dynamic;
-      var badTableIndex = internalIds.indexOf(badTableElement.$__root__.id);
+      var badTableIndex =
+          internalIds.indexOf(badTableElement.$__root__.id as String);
       if (badTableIndex >= 0 && badTableIndex < closestIndex) {
         closestIndex = badTableIndex;
         closestValue = (ids) =>
@@ -219,7 +217,6 @@ mixin $$BaseObject on BaseObject {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -298,8 +295,6 @@ class $PseudoBaseObject extends PseudoBaseObject with $$PseudoBaseObject {
 
 mixin $$PseudoBaseObject on PseudoBaseObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPseudoBaseObject() {
     return {};
@@ -333,7 +328,7 @@ mixin $$PseudoBaseObject on PseudoBaseObject {
     String Function(List<String>) closestValue;
     try {
       var tableElement = this.table as dynamic;
-      var tableIndex = internalIds.indexOf(tableElement.$__root__.id);
+      var tableIndex = internalIds.indexOf(tableElement.$__root__.id as String);
       if (tableIndex >= 0 && tableIndex < closestIndex) {
         closestIndex = tableIndex;
         closestValue = (ids) => 'table.${tableElement.findChain(ids, action)}'
@@ -344,7 +339,8 @@ mixin $$PseudoBaseObject on PseudoBaseObject {
     }
     try {
       var badTableElement = this.badTable as dynamic;
-      var badTableIndex = internalIds.indexOf(badTableElement.$__root__.id);
+      var badTableIndex =
+          internalIds.indexOf(badTableElement.$__root__.id as String);
       if (badTableIndex >= 0 && badTableIndex < closestIndex) {
         closestIndex = badTableIndex;
         closestValue = (ids) =>
@@ -405,7 +401,6 @@ mixin $$PseudoBaseObject on PseudoBaseObject {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -481,8 +476,6 @@ class $TableForCheckTag extends TableForCheckTag with $$TableForCheckTag {
 
 mixin $$TableForCheckTag on TableForCheckTag {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInTableForCheckTag() {
     return {};
@@ -575,7 +568,6 @@ mixin $$TableForCheckTag on TableForCheckTag {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -654,8 +646,6 @@ class $BaseEnsureObject extends BaseEnsureObject with $$BaseEnsureObject {
 
 mixin $$BaseEnsureObject on BaseEnsureObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInBaseEnsureObject() {
     return {};
@@ -686,7 +676,7 @@ mixin $$BaseEnsureObject on BaseEnsureObject {
     String Function(List<String>) closestValue;
     try {
       var tableElement = this.table as dynamic;
-      var tableIndex = internalIds.indexOf(tableElement.$__root__.id);
+      var tableIndex = internalIds.indexOf(tableElement.$__root__.id as String);
       if (tableIndex >= 0 && tableIndex < closestIndex) {
         closestIndex = tableIndex;
         closestValue = (ids) => 'table.${tableElement.findChain(ids, action)}'
@@ -697,7 +687,8 @@ mixin $$BaseEnsureObject on BaseEnsureObject {
     }
     try {
       var badTableElement = this.badTable as dynamic;
-      var badTableIndex = internalIds.indexOf(badTableElement.$__root__.id);
+      var badTableIndex =
+          internalIds.indexOf(badTableElement.$__root__.id as String);
       if (badTableIndex >= 0 && badTableIndex < closestIndex) {
         closestIndex = badTableIndex;
         closestValue = (ids) =>
@@ -735,7 +726,6 @@ mixin $$BaseEnsureObject on BaseEnsureObject {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -811,8 +801,6 @@ class $TableForEnsureTag extends TableForEnsureTag with $$TableForEnsureTag {
 
 mixin $$TableForEnsureTag on TableForEnsureTag {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInTableForEnsureTag() {
     return {};
@@ -880,7 +868,6 @@ mixin $$TableForEnsureTag on TableForEnsureTag {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -956,8 +943,6 @@ class $CheckTagFails extends CheckTagFails with $$CheckTagFails {
 
 mixin $$CheckTagFails on CheckTagFails {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInCheckTagFails() {
     return {};
@@ -1008,7 +993,6 @@ mixin $$CheckTagFails on CheckTagFails {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -1085,8 +1069,6 @@ class $EnsureTagFails extends EnsureTagFails with $$EnsureTagFails {
 
 mixin $$EnsureTagFails on EnsureTagFails {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInEnsureTagFails() {
     return {};
@@ -1137,7 +1119,6 @@ mixin $$EnsureTagFails on EnsureTagFails {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -1219,8 +1200,6 @@ class $PageForWithAttributeTest extends PageForWithAttributeTest
 
 mixin $$PageForWithAttributeTest on PageForWithAttributeTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForWithAttributeTest() {
     return {};
@@ -1273,7 +1252,6 @@ mixin $$PageForWithAttributeTest on PageForWithAttributeTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -1354,8 +1332,6 @@ class $PageForWithClassTest extends PageForWithClassTest
 
 mixin $$PageForWithClassTest on PageForWithClassTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForWithClassTest() {
     return {};
@@ -1408,7 +1384,6 @@ mixin $$PageForWithClassTest on PageForWithClassTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -1487,8 +1462,6 @@ class $DebugIds extends DebugIds with $$DebugIds {
 
 mixin $$DebugIds on DebugIds {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInDebugIds() {
     return {};
@@ -1667,7 +1640,6 @@ mixin $$DebugIds on DebugIds {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -1746,8 +1718,6 @@ class $TestIds extends TestIds with $$TestIds {
 
 mixin $$TestIds on TestIds {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInTestIds() {
     return {};

--- a/test/src/attributes.g.dart
+++ b/test/src/attributes.g.dart
@@ -6,7 +6,6 @@ part of 'attributes.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -88,8 +87,6 @@ class $PageForAttributesTests extends PageForAttributesTests
 
 mixin $$PageForAttributesTests on PageForAttributesTests {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForAttributesTests() {
     return {};

--- a/test/src/basic.g.dart
+++ b/test/src/basic.g.dart
@@ -6,15 +6,12 @@ part of 'basic.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$MixinPO on MixinPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInMixinPO() {
     return {
@@ -61,8 +58,6 @@ mixin $$MixinPO on MixinPO {
     return {closestIndex: closestValue};
   }
 
-  String get mixinDivText;
-  String get getterMessage;
   PageLoaderElement get _mixinDiv {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('MixinPO', '_mixinDiv');
@@ -76,7 +71,6 @@ mixin $$MixinPO on MixinPO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -155,8 +149,6 @@ class $PageForExistsTest extends PageForExistsTest with $$PageForExistsTest {
 
 mixin $$PageForExistsTest on PageForExistsTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForExistsTest() {
     return {};
@@ -258,7 +250,6 @@ mixin $$PageForExistsTest on PageForExistsTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -339,8 +330,6 @@ class $PageForVisibilityTest extends PageForVisibilityTest
 
 mixin $$PageForVisibilityTest on PageForVisibilityTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForVisibilityTest() {
     return {};
@@ -418,7 +407,6 @@ mixin $$PageForVisibilityTest on PageForVisibilityTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -501,8 +489,6 @@ class $PageForClassAnnotationTest extends PageForClassAnnotationTest
 
 mixin $$PageForClassAnnotationTest on PageForClassAnnotationTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForClassAnnotationTest() {
     return {};
@@ -530,7 +516,7 @@ mixin $$PageForClassAnnotationTest on PageForClassAnnotationTest {
     String Function(List<String>) closestValue;
     try {
       var tableElement = this.table as dynamic;
-      var tableIndex = internalIds.indexOf(tableElement.$__root__.id);
+      var tableIndex = internalIds.indexOf(tableElement.$__root__.id as String);
       if (tableIndex >= 0 && tableIndex < closestIndex) {
         closestIndex = tableIndex;
         closestValue = (ids) => 'table.${tableElement.findChain(ids, action)}'
@@ -555,7 +541,6 @@ mixin $$PageForClassAnnotationTest on PageForClassAnnotationTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -648,8 +633,6 @@ class $PageForPrivateFieldsTest extends PageForPrivateFieldsTest
 
 mixin $$PageForPrivateFieldsTest on PageForPrivateFieldsTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForPrivateFieldsTest() {
     return {};
@@ -675,7 +658,7 @@ mixin $$PageForPrivateFieldsTest on PageForPrivateFieldsTest {
     try {
       // Do not know the type. Try it out and ignore if not successful.
       var tableElement = this.table as dynamic;
-      var tableIndex = internalIds.indexOf(tableElement.$__root__.id);
+      var tableIndex = internalIds.indexOf(tableElement.$__root__.id as String);
       if (tableIndex >= 0 && tableIndex < closestIndex) {
         closestIndex = tableIndex;
         closestValue = (ids) => 'table.${tableElement.findChain(ids, action)}'
@@ -687,7 +670,7 @@ mixin $$PageForPrivateFieldsTest on PageForPrivateFieldsTest {
     try {
       var _privateTableElement = this._privateTable as dynamic;
       var _privateTableIndex =
-          internalIds.indexOf(_privateTableElement.$__root__.id);
+          internalIds.indexOf(_privateTableElement.$__root__.id as String);
       if (_privateTableIndex >= 0 && _privateTableIndex < closestIndex) {
         closestIndex = _privateTableIndex;
         closestValue = (ids) =>
@@ -700,7 +683,6 @@ mixin $$PageForPrivateFieldsTest on PageForPrivateFieldsTest {
     return {closestIndex: closestValue};
   }
 
-  Table get table;
   Table get _privateTable {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod(
@@ -716,7 +698,6 @@ mixin $$PageForPrivateFieldsTest on PageForPrivateFieldsTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -795,8 +776,6 @@ class $PageForFocusTest extends PageForFocusTest with $$PageForFocusTest {
 
 mixin $$PageForFocusTest on PageForFocusTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForFocusTest() {
     return {};
@@ -848,7 +827,6 @@ mixin $$PageForFocusTest on PageForFocusTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -927,8 +905,6 @@ class $PageForNbspTest extends PageForNbspTest with $$PageForNbspTest {
 
 mixin $$PageForNbspTest on PageForNbspTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForNbspTest() {
     return {};
@@ -979,7 +955,6 @@ mixin $$PageForNbspTest on PageForNbspTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -1057,8 +1032,6 @@ class $Basic extends Basic with $$Basic {
 
 mixin $$Basic on Basic {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInBasic() {
     return {};
@@ -1086,7 +1059,7 @@ mixin $$Basic on Basic {
     try {
       var outerNestedElement = this.outerNested as dynamic;
       var outerNestedIndex =
-          internalIds.indexOf(outerNestedElement.$__root__.id);
+          internalIds.indexOf(outerNestedElement.$__root__.id as String);
       if (outerNestedIndex >= 0 && outerNestedIndex < closestIndex) {
         closestIndex = outerNestedIndex;
         closestValue = (ids) =>
@@ -1112,7 +1085,6 @@ mixin $$Basic on Basic {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -1191,8 +1163,6 @@ class $OuterNested extends OuterNested with $$OuterNested {
 
 mixin $$OuterNested on OuterNested {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInOuterNested() {
     return {};
@@ -1243,7 +1213,6 @@ mixin $$OuterNested on OuterNested {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -1322,8 +1291,6 @@ class $DebugId extends DebugId with $$DebugId {
 
 mixin $$DebugId on DebugId {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInDebugId() {
     return {};
@@ -1374,7 +1341,6 @@ mixin $$DebugId on DebugId {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -1453,8 +1419,6 @@ class $Display extends Display with $$Display {
 
 mixin $$Display on Display {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInDisplay() {
     return {};
@@ -1505,15 +1469,12 @@ mixin $$Display on Display {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$ClassMixinPO on ClassMixinPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInClassMixinPO() {
     return {
@@ -1560,8 +1521,6 @@ mixin $$ClassMixinPO on ClassMixinPO {
     return {closestIndex: closestValue};
   }
 
-  String get mixinDivText;
-  String get getterMessage;
   PageLoaderElement get _mixinDiv {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('ClassMixinPO', '_mixinDiv');
@@ -1575,7 +1534,6 @@ mixin $$ClassMixinPO on ClassMixinPO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -1667,8 +1625,6 @@ class $POWithClassMixinPO extends POWithClassMixinPO
 
 mixin $$POWithClassMixinPO on POWithClassMixinPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPOWithClassMixinPO() {
     return {};
@@ -1695,7 +1651,6 @@ mixin $$POWithClassMixinPO on POWithClassMixinPO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -1786,8 +1741,6 @@ class $POWithMixinPO extends POWithMixinPO with $$MixinPO, $$POWithMixinPO {
 
 mixin $$POWithMixinPO on POWithMixinPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPOWithMixinPO() {
     return {};

--- a/test/src/cache_invalidation.g.dart
+++ b/test/src/cache_invalidation.g.dart
@@ -6,7 +6,6 @@ part of 'cache_invalidation.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -85,8 +84,6 @@ class $CacheInvalidation extends CacheInvalidation with $$CacheInvalidation {
 
 mixin $$CacheInvalidation on CacheInvalidation {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInCacheInvalidation() {
     return {};
@@ -117,7 +114,8 @@ mixin $$CacheInvalidation on CacheInvalidation {
     String Function(List<String>) closestValue;
     try {
       var select1Element = this.select1 as dynamic;
-      var select1Index = internalIds.indexOf(select1Element.$__root__.id);
+      var select1Index =
+          internalIds.indexOf(select1Element.$__root__.id as String);
       if (select1Index >= 0 && select1Index < closestIndex) {
         closestIndex = select1Index;
         closestValue = (ids) =>
@@ -165,7 +163,6 @@ mixin $$CacheInvalidation on CacheInvalidation {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -244,8 +241,6 @@ class $_Nested extends _Nested with $$_Nested {
 
 mixin $$_Nested on _Nested {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersIn_Nested() {
     return {};

--- a/test/src/constructors.g.dart
+++ b/test/src/constructors.g.dart
@@ -6,7 +6,6 @@ part of 'constructors.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -85,8 +84,6 @@ class $BasePO extends BasePO with $$BasePO {
 
 mixin $$BasePO on BasePO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInBasePO() {
     return {};
@@ -113,7 +110,8 @@ mixin $$BasePO on BasePO {
     String Function(List<String>) closestValue;
     try {
       var bTagPOElement = this.bTagPO as dynamic;
-      var bTagPOIndex = internalIds.indexOf(bTagPOElement.$__root__.id);
+      var bTagPOIndex =
+          internalIds.indexOf(bTagPOElement.$__root__.id as String);
       if (bTagPOIndex >= 0 && bTagPOIndex < closestIndex) {
         closestIndex = bTagPOIndex;
         closestValue = (ids) => 'bTagPO.${bTagPOElement.findChain(ids, action)}'
@@ -139,7 +137,6 @@ mixin $$BasePO on BasePO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -270,8 +267,6 @@ class $BCustomTagPO extends BCustomTagPO with $$BCustomTagPO {
 
 mixin $$BCustomTagPO on BCustomTagPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInBCustomTagPO() {
     return {};
@@ -306,7 +301,8 @@ mixin $$BCustomTagPO on BCustomTagPO {
     try {
       // Do not know the type. Try it out and ignore if not successful.
       var _utilsElement = this._utils as dynamic;
-      var _utilsIndex = internalIds.indexOf(_utilsElement.$__root__.id);
+      var _utilsIndex =
+          internalIds.indexOf(_utilsElement.$__root__.id as String);
       if (_utilsIndex >= 0 && _utilsIndex < closestIndex) {
         closestIndex = _utilsIndex;
         closestValue = (ids) => '_utils.${_utilsElement.findChain(ids, action)}'
@@ -319,7 +315,7 @@ mixin $$BCustomTagPO on BCustomTagPO {
       // Do not know the type. Try it out and ignore if not successful.
       var cTagFromPLEElement = this.cTagFromPLE as dynamic;
       var cTagFromPLEIndex =
-          internalIds.indexOf(cTagFromPLEElement.$__root__.id);
+          internalIds.indexOf(cTagFromPLEElement.$__root__.id as String);
       if (cTagFromPLEIndex >= 0 && cTagFromPLEIndex < closestIndex) {
         closestIndex = cTagFromPLEIndex;
         closestValue = (ids) =>
@@ -333,7 +329,7 @@ mixin $$BCustomTagPO on BCustomTagPO {
       // Do not know the type. Try it out and ignore if not successful.
       var cTagFromUtilsElement = this.cTagFromUtils as dynamic;
       var cTagFromUtilsIndex =
-          internalIds.indexOf(cTagFromUtilsElement.$__root__.id);
+          internalIds.indexOf(cTagFromUtilsElement.$__root__.id as String);
       if (cTagFromUtilsIndex >= 0 && cTagFromUtilsIndex < closestIndex) {
         closestIndex = cTagFromUtilsIndex;
         closestValue = (ids) =>
@@ -346,7 +342,8 @@ mixin $$BCustomTagPO on BCustomTagPO {
     try {
       // Do not know the type. Try it out and ignore if not successful.
       var noLookupPOElement = this.noLookupPO as dynamic;
-      var noLookupPOIndex = internalIds.indexOf(noLookupPOElement.$__root__.id);
+      var noLookupPOIndex =
+          internalIds.indexOf(noLookupPOElement.$__root__.id as String);
       if (noLookupPOIndex >= 0 && noLookupPOIndex < closestIndex) {
         closestIndex = noLookupPOIndex;
         closestValue = (ids) =>
@@ -369,11 +366,6 @@ mixin $$BCustomTagPO on BCustomTagPO {
     return {closestIndex: closestValue};
   }
 
-  PageLoaderElement get rootElement;
-  PageUtils get _utils;
-  CCustomTagPO get cTagFromPLE;
-  CCustomTagPO get cTagFromUtils;
-  NoLookupPO get noLookupPO;
   PageLoaderElement get _root {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('BCustomTagPO', '_root');
@@ -387,7 +379,6 @@ mixin $$BCustomTagPO on BCustomTagPO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -474,8 +465,6 @@ class $CCustomTagPO extends CCustomTagPO with $$CCustomTagPO {
 
 mixin $$CCustomTagPO on CCustomTagPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInCCustomTagPO() {
     return {
@@ -515,7 +504,6 @@ mixin $$CCustomTagPO on CCustomTagPO {
     return {closestIndex: closestValue};
   }
 
-  String get innerText;
   PageLoaderElement get _root {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('CCustomTagPO', '_root');
@@ -529,7 +517,6 @@ mixin $$CCustomTagPO on CCustomTagPO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -608,8 +595,6 @@ class $NoLookupPO extends NoLookupPO with $$NoLookupPO {
 
 mixin $$NoLookupPO on NoLookupPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInNoLookupPO() {
     return {};

--- a/test/src/findchain.g.dart
+++ b/test/src/findchain.g.dart
@@ -6,7 +6,6 @@ part of 'findchain.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -98,8 +97,6 @@ class $PageForFindChainTests extends PageForFindChainTests
 
 mixin $$PageForFindChainTests on PageForFindChainTests {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForFindChainTests() {
     return {};
@@ -140,7 +137,8 @@ mixin $$PageForFindChainTests on PageForFindChainTests {
     try {
       // Do not know the type. Try it out and ignore if not successful.
       var firstOuterElement = this.firstOuter as dynamic;
-      var firstOuterIndex = internalIds.indexOf(firstOuterElement.$__root__.id);
+      var firstOuterIndex =
+          internalIds.indexOf(firstOuterElement.$__root__.id as String);
       if (firstOuterIndex >= 0 && firstOuterIndex < closestIndex) {
         closestIndex = firstOuterIndex;
         closestValue = (ids) =>
@@ -152,7 +150,8 @@ mixin $$PageForFindChainTests on PageForFindChainTests {
     }
     try {
       var customElement = this.custom as dynamic;
-      var customIndex = internalIds.indexOf(customElement.$__root__.id);
+      var customIndex =
+          internalIds.indexOf(customElement.$__root__.id as String);
       if (customIndex >= 0 && customIndex < closestIndex) {
         closestIndex = customIndex;
         closestValue = (ids) => 'custom.${customElement.findChain(ids, action)}'
@@ -163,7 +162,7 @@ mixin $$PageForFindChainTests on PageForFindChainTests {
     }
     try {
       var tableElement = this.table as dynamic;
-      var tableIndex = internalIds.indexOf(tableElement.$__root__.id);
+      var tableIndex = internalIds.indexOf(tableElement.$__root__.id as String);
       if (tableIndex >= 0 && tableIndex < closestIndex) {
         closestIndex = tableIndex;
         closestValue = (ids) => 'table.${tableElement.findChain(ids, action)}'
@@ -178,7 +177,8 @@ mixin $$PageForFindChainTests on PageForFindChainTests {
         elementIter++) {
       try {
         var outersElement = outersElements[elementIter] as dynamic;
-        var outersIndex = internalIds.indexOf(outersElement.$__root__.id);
+        var outersIndex =
+            internalIds.indexOf(outersElement.$__root__.id as String);
         if (outersIndex >= 0 && outersIndex < closestIndex) {
           closestIndex = outersIndex;
           closestValue = (ids) =>
@@ -195,7 +195,8 @@ mixin $$PageForFindChainTests on PageForFindChainTests {
         elementIter++) {
       try {
         var customPOsElement = customPOsElements[elementIter] as dynamic;
-        var customPOsIndex = internalIds.indexOf(customPOsElement.$__root__.id);
+        var customPOsIndex =
+            internalIds.indexOf(customPOsElement.$__root__.id as String);
         if (customPOsIndex >= 0 && customPOsIndex < closestIndex) {
           closestIndex = customPOsIndex;
           closestValue = (ids) =>
@@ -224,7 +225,6 @@ mixin $$PageForFindChainTests on PageForFindChainTests {
     return {closestIndex: closestValue};
   }
 
-  OuterPO get firstOuter;
   CustomPO get custom {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageForFindChainTests', 'custom');
@@ -289,7 +289,6 @@ mixin $$PageForFindChainTests on PageForFindChainTests {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -365,8 +364,6 @@ class $CustomPO extends CustomPO with $$CustomPO {
 
 mixin $$CustomPO on CustomPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInCustomPO() {
     return {};
@@ -392,7 +389,6 @@ mixin $$CustomPO on CustomPO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -494,8 +490,6 @@ class $OuterPO extends OuterPO with $$OuterMixin, $$OuterPO {
 
 mixin $$OuterPO on OuterPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInOuterPO() {
     return {};
@@ -556,7 +550,6 @@ mixin $$OuterPO on OuterPO {
     return {closestIndex: closestValue};
   }
 
-  PageLoaderElement get firstInner;
   PageLoaderElement get specialInner {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('OuterPO', 'specialInner');
@@ -582,15 +575,12 @@ mixin $$OuterPO on OuterPO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$OuterMixin on OuterMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInOuterMixin() {
     return {};
@@ -647,7 +637,6 @@ mixin $$OuterMixin on OuterMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -726,8 +715,6 @@ class $TablePO extends TablePO with $$TablePO {
 
 mixin $$TablePO on TablePO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInTablePO() {
     return {};
@@ -758,7 +745,7 @@ mixin $$TablePO on TablePO {
         elementIter++) {
       try {
         var rowsElement = rowsElements[elementIter] as dynamic;
-        var rowsIndex = internalIds.indexOf(rowsElement.$__root__.id);
+        var rowsIndex = internalIds.indexOf(rowsElement.$__root__.id as String);
         if (rowsIndex >= 0 && rowsIndex < closestIndex) {
           closestIndex = rowsIndex;
           closestValue = (ids) =>
@@ -786,7 +773,6 @@ mixin $$TablePO on TablePO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -864,8 +850,6 @@ class $RowPO extends RowPO with $$RowPO {
 
 mixin $$RowPO on RowPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInRowPO() {
     return {};

--- a/test/src/generics.g.dart
+++ b/test/src/generics.g.dart
@@ -6,7 +6,6 @@ part of 'generics.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -96,8 +95,6 @@ class $Generics<T> extends Generics<T> with $$Generics<T> {
 
 mixin $$Generics<T> on Generics<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInGenerics() {
     return {};
@@ -127,7 +124,6 @@ mixin $$Generics<T> on Generics<T> {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -206,8 +202,6 @@ class $RootPo<T> extends RootPo<T> with $$RootPo<T> {
 
 mixin $$RootPo<T> on RootPo<T> {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInRootPo() {
     return {};
@@ -237,7 +231,8 @@ mixin $$RootPo<T> on RootPo<T> {
     String Function(List<String>) closestValue;
     try {
       var genericsElement = this.generics as dynamic;
-      var genericsIndex = internalIds.indexOf(genericsElement.$__root__.id);
+      var genericsIndex =
+          internalIds.indexOf(genericsElement.$__root__.id as String);
       if (genericsIndex >= 0 && genericsIndex < closestIndex) {
         closestIndex = genericsIndex;
         closestValue = (ids) =>
@@ -254,7 +249,7 @@ mixin $$RootPo<T> on RootPo<T> {
       try {
         var genericsListElement = genericsListElements[elementIter] as dynamic;
         var genericsListIndex =
-            internalIds.indexOf(genericsListElement.$__root__.id);
+            internalIds.indexOf(genericsListElement.$__root__.id as String);
         if (genericsListIndex >= 0 && genericsListIndex < closestIndex) {
           closestIndex = genericsListIndex;
           closestValue = (ids) =>

--- a/test/src/list.dart
+++ b/test/src/list.dart
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'package:pageloader/pageloader.dart';
 import 'package:test/test.dart';
 

--- a/test/src/list.g.dart
+++ b/test/src/list.g.dart
@@ -6,7 +6,6 @@ part of 'list.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -84,8 +83,6 @@ class $Lists extends Lists with $$Lists {
 
 mixin $$Lists on Lists {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInLists() {
     return {};
@@ -123,8 +120,8 @@ mixin $$Lists on Lists {
       try {
         var tableRowsSyncAsPOElement =
             tableRowsSyncAsPOElements[elementIter] as dynamic;
-        var tableRowsSyncAsPOIndex =
-            internalIds.indexOf(tableRowsSyncAsPOElement.$__root__.id);
+        var tableRowsSyncAsPOIndex = internalIds
+            .indexOf(tableRowsSyncAsPOElement.$__root__.id as String);
         if (tableRowsSyncAsPOIndex >= 0 &&
             tableRowsSyncAsPOIndex < closestIndex) {
           closestIndex = tableRowsSyncAsPOIndex;
@@ -195,7 +192,6 @@ mixin $$Lists on Lists {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -281,8 +277,6 @@ class $RowPO extends RowPO with $$RowPO {
 
 mixin $$RowPO on RowPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInRowPO() {
     return {
@@ -322,7 +316,6 @@ mixin $$RowPO on RowPO {
     return {closestIndex: closestValue};
   }
 
-  bool get exists;
   PageLoaderElement get _root {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('RowPO', '_root');

--- a/test/src/long_exception.g.dart
+++ b/test/src/long_exception.g.dart
@@ -6,7 +6,6 @@ part of 'long_exception.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -85,8 +84,6 @@ class $MyPageObject extends MyPageObject with $$MyPageObject {
 
 mixin $$MyPageObject on MyPageObject {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInMyPageObject() {
     return {};

--- a/test/src/mouse.dart
+++ b/test/src/mouse.dart
@@ -31,7 +31,7 @@ void runTests(GetNewContext contextGenerator) {
       await mouse.down(MouseButton.primary);
       await waitFor(() => page.element.visibleText,
           matcher: contains('MouseDown'));
-      await mouse.moveTo(page.element, 10, 10);
+      await mouse.moveTo(page.element, 3, 3);
       await mouse.up(MouseButton.primary);
       await waitFor(() => page.element.visibleText,
           matcher: contains('MouseUp'));

--- a/test/src/mouse.g.dart
+++ b/test/src/mouse.g.dart
@@ -6,7 +6,6 @@ part of 'mouse.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -86,7 +85,6 @@ class $PageForMouseTest extends PageForMouseTest with $$PageForMouseTest {
 mixin $$PageForMouseTest on PageForMouseTest {
   PageLoaderElement $__root__;
   PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForMouseTest() {
     return {};

--- a/test/src/null_element.g.dart
+++ b/test/src/null_element.g.dart
@@ -6,7 +6,6 @@ part of 'null_element.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -107,8 +106,6 @@ class $BasePO extends BasePO with $$BasePO {
 
 mixin $$BasePO on BasePO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInBasePO() {
     return {
@@ -153,7 +150,8 @@ mixin $$BasePO on BasePO {
     String Function(List<String>) closestValue;
     try {
       var buttonPOElement = this.buttonPO as dynamic;
-      var buttonPOIndex = internalIds.indexOf(buttonPOElement.$__root__.id);
+      var buttonPOIndex =
+          internalIds.indexOf(buttonPOElement.$__root__.id as String);
       if (buttonPOIndex >= 0 && buttonPOIndex < closestIndex) {
         closestIndex = buttonPOIndex;
         closestValue = (ids) =>
@@ -166,7 +164,7 @@ mixin $$BasePO on BasePO {
     try {
       var nullButtonPOElement = this.nullButtonPO as dynamic;
       var nullButtonPOIndex =
-          internalIds.indexOf(nullButtonPOElement.$__root__.id);
+          internalIds.indexOf(nullButtonPOElement.$__root__.id as String);
       if (nullButtonPOIndex >= 0 && nullButtonPOIndex < closestIndex) {
         closestIndex = nullButtonPOIndex;
         closestValue = (ids) =>
@@ -178,7 +176,8 @@ mixin $$BasePO on BasePO {
     }
     try {
       var _nullRowPOElement = this._nullRowPO as dynamic;
-      var _nullRowPOIndex = internalIds.indexOf(_nullRowPOElement.$__root__.id);
+      var _nullRowPOIndex =
+          internalIds.indexOf(_nullRowPOElement.$__root__.id as String);
       if (_nullRowPOIndex >= 0 && _nullRowPOIndex < closestIndex) {
         closestIndex = _nullRowPOIndex;
         closestValue = (ids) =>
@@ -194,7 +193,8 @@ mixin $$BasePO on BasePO {
         elementIter++) {
       try {
         var _rowPOsElement = _rowPOsElements[elementIter] as dynamic;
-        var _rowPOsIndex = internalIds.indexOf(_rowPOsElement.$__root__.id);
+        var _rowPOsIndex =
+            internalIds.indexOf(_rowPOsElement.$__root__.id as String);
         if (_rowPOsIndex >= 0 && _rowPOsIndex < closestIndex) {
           closestIndex = _rowPOsIndex;
           closestValue = (ids) =>
@@ -254,8 +254,6 @@ mixin $$BasePO on BasePO {
     return {closestIndex: closestValue};
   }
 
-  List<PageLoaderElement> get allRows;
-  List<RowPO> get allRowPOs;
   PageLoaderElement get button {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('BasePO', 'button');
@@ -355,7 +353,6 @@ mixin $$BasePO on BasePO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -434,8 +431,6 @@ class $ButtonPO extends ButtonPO with $$ButtonPO {
 
 mixin $$ButtonPO on ButtonPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInButtonPO() {
     return {};
@@ -461,7 +456,6 @@ mixin $$ButtonPO on ButtonPO {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -539,8 +533,6 @@ class $RowPO extends RowPO with $$RowPO {
 
 mixin $$RowPO on RowPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInRowPO() {
     return {};

--- a/test/src/page_utils.g.dart
+++ b/test/src/page_utils.g.dart
@@ -6,7 +6,6 @@ part of 'page_utils.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -87,8 +86,6 @@ class $PageForPageUtilsTests extends PageForPageUtilsTests
 
 mixin $$PageForPageUtilsTests on PageForPageUtilsTests {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForPageUtilsTests() {
     return {};

--- a/test/src/pointer.g.dart
+++ b/test/src/pointer.g.dart
@@ -6,7 +6,6 @@ part of 'pointer.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -85,7 +84,6 @@ class $PageForPointerTest extends PageForPointerTest with $$PageForPointerTest {
 
 mixin $$PageForPointerTest on PageForPointerTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
   PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForPointerTest() {

--- a/test/src/properties.g.dart
+++ b/test/src/properties.g.dart
@@ -6,7 +6,6 @@ part of 'properties.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -88,8 +87,6 @@ class $PageForPropertiesTests extends PageForPropertiesTests
 
 mixin $$PageForPropertiesTests on PageForPropertiesTests {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForPropertiesTests() {
     return {};

--- a/test/src/scroll.dart
+++ b/test/src/scroll.dart
@@ -46,34 +46,34 @@ void runTests(GetNewContext contextGenerator) {
     test('x right', () async {
       expect(scrollPO.scrollLeft, 0);
       expect(scrollPO.scrollTop, 0);
-      await scrollPO.scroll(x: 50);
-      expect(scrollPO.scrollLeft, 50);
+      await scrollPO.scroll(x: 40);
+      expect(scrollPO.scrollLeft, 40);
       expect(scrollPO.scrollTop, 0);
     });
 
     test('x right then left', () async {
       expect(scrollPO.scrollLeft, 0);
       expect(scrollPO.scrollTop, 0);
-      await scrollPO.scroll(x: 50);
+      await scrollPO.scroll(x: 40);
       await scrollPO.scroll(x: -30);
-      expect(scrollPO.scrollLeft, 20);
+      expect(scrollPO.scrollLeft, 10);
       expect(scrollPO.scrollTop, 0);
     });
 
     test('x and y', () async {
       expect(scrollPO.scrollLeft, 0);
       expect(scrollPO.scrollTop, 0);
-      await scrollPO.scroll(x: 50, y: 500);
-      expect(scrollPO.scrollLeft, 50);
+      await scrollPO.scroll(x: 40, y: 500);
+      expect(scrollPO.scrollLeft, 40);
       expect(scrollPO.scrollTop, 500);
     });
 
     test('x and y reverse', () async {
       expect(scrollPO.scrollLeft, 0);
       expect(scrollPO.scrollTop, 0);
-      await scrollPO.scroll(x: 50, y: 500);
+      await scrollPO.scroll(x: 40, y: 500);
       await scrollPO.scroll(x: -30, y: -300);
-      expect(scrollPO.scrollLeft, 20);
+      expect(scrollPO.scrollLeft, 10);
       expect(scrollPO.scrollTop, 200);
     });
 

--- a/test/src/scroll.g.dart
+++ b/test/src/scroll.g.dart
@@ -6,7 +6,6 @@ part of 'scroll.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -118,8 +117,6 @@ class $ScrollPO extends ScrollPO with $$ScrollPO {
 
 mixin $$ScrollPO on ScrollPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInScrollPO() {
     return {
@@ -204,8 +201,6 @@ mixin $$ScrollPO on ScrollPO {
     return {closestIndex: closestValue};
   }
 
-  int get scrollLeft;
-  int get scrollTop;
   PageLoaderElement get _scrollBox {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('ScrollPO', '_scrollBox');

--- a/test/src/shared_list_page_objects.dart
+++ b/test/src/shared_list_page_objects.dart
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
 import 'package:pageloader/pageloader.dart';
 import 'package:test/test.dart';
 

--- a/test/src/shared_list_page_objects.g.dart
+++ b/test/src/shared_list_page_objects.g.dart
@@ -6,7 +6,6 @@ part of 'shared_list_page_objects.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -85,8 +84,6 @@ class $PageForSimpleTest extends PageForSimpleTest with $$PageForSimpleTest {
 
 mixin $$PageForSimpleTest on PageForSimpleTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForSimpleTest() {
     return {};
@@ -117,7 +114,7 @@ mixin $$PageForSimpleTest on PageForSimpleTest {
     String Function(List<String>) closestValue;
     try {
       var tableElement = this.table as dynamic;
-      var tableIndex = internalIds.indexOf(tableElement.$__root__.id);
+      var tableIndex = internalIds.indexOf(tableElement.$__root__.id as String);
       if (tableIndex >= 0 && tableIndex < closestIndex) {
         closestIndex = tableIndex;
         closestValue = (ids) => 'table.${tableElement.findChain(ids, action)}'
@@ -164,7 +161,6 @@ mixin $$PageForSimpleTest on PageForSimpleTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -242,8 +238,6 @@ class $Table extends Table with $$Table {
 
 mixin $$Table on Table {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInTable() {
     return {};
@@ -280,7 +274,8 @@ mixin $$Table on Table {
         elementIter++) {
       try {
         var rowsSyncElement = rowsSyncElements[elementIter] as dynamic;
-        var rowsSyncIndex = internalIds.indexOf(rowsSyncElement.$__root__.id);
+        var rowsSyncIndex =
+            internalIds.indexOf(rowsSyncElement.$__root__.id as String);
         if (rowsSyncIndex >= 0 && rowsSyncIndex < closestIndex) {
           closestIndex = rowsSyncIndex;
           closestValue = (ids) =>
@@ -343,7 +338,6 @@ mixin $$Table on Table {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -421,8 +415,6 @@ class $Row extends Row with $$Row {
 
 mixin $$Row on Row {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInRow() {
     return {};

--- a/test/src/shared_page_objects.dart
+++ b/test/src/shared_page_objects.dart
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
 import 'package:pageloader/pageloader.dart';
 import 'package:test/test.dart';
 

--- a/test/src/shared_page_objects.g.dart
+++ b/test/src/shared_page_objects.g.dart
@@ -6,7 +6,6 @@ part of 'shared_page_objects.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -85,8 +84,6 @@ class $PageForSimpleTest extends PageForSimpleTest with $$PageForSimpleTest {
 
 mixin $$PageForSimpleTest on PageForSimpleTest {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForSimpleTest() {
     return {};
@@ -114,7 +111,7 @@ mixin $$PageForSimpleTest on PageForSimpleTest {
     String Function(List<String>) closestValue;
     try {
       var tableElement = this.table as dynamic;
-      var tableIndex = internalIds.indexOf(tableElement.$__root__.id);
+      var tableIndex = internalIds.indexOf(tableElement.$__root__.id as String);
       if (tableIndex >= 0 && tableIndex < closestIndex) {
         closestIndex = tableIndex;
         closestValue = (ids) => 'table.${tableElement.findChain(ids, action)}'
@@ -139,7 +136,6 @@ mixin $$PageForSimpleTest on PageForSimpleTest {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -228,8 +224,6 @@ class $Table extends Table with $$Table {
 
 mixin $$Table on Table {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInTable() {
     return {};
@@ -301,7 +295,6 @@ mixin $$Table on Table {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -379,8 +372,6 @@ class $Row extends Row with $$Row {
 
 mixin $$Row on Row {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInRow() {
     return {};

--- a/test/src/source_support.dart
+++ b/test/src/source_support.dart
@@ -37,7 +37,6 @@ Future<MethodDeclaration> getMethodDeclaration(
     String methodDeclaration, String methodName,
     {String preamble = ''}) async {
   final classToParse = '''
-import 'dart:async';
 import '/test/root/path/annotations.dart';
 import '/test/root/path/annotation_interfaces.dart';
 

--- a/test/src/source_support.dart
+++ b/test/src/source_support.dart
@@ -11,12 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/analysis/session.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type_provider.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:analyzer/src/dart/analysis/byte_store.dart';
@@ -24,7 +23,6 @@ import 'package:analyzer/src/dart/analysis/driver.dart';
 import 'package:analyzer/src/dart/analysis/file_state.dart';
 import 'package:analyzer/src/dart/analysis/performance_logger.dart';
 import 'package:analyzer/src/generated/engine.dart';
-import 'package:analyzer/src/generated/resolver.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/test_utilities/mock_sdk.dart';
 import 'package:path/path.dart' as pather;
@@ -88,7 +86,8 @@ class TestDriver {
 
   CompilationUnit get compilationUnit => _compilationUnit;
 
-  Future<TypeProvider> get typeProvider => session.typeProvider;
+  Future<TypeProvider> get typeProvider async =>
+      compilationUnitElement.library.typeProvider;
 
   TestDriver() {
     final byteStore = MemoryByteStore();

--- a/test/src/test_creator_getters.g.dart
+++ b/test/src/test_creator_getters.g.dart
@@ -6,7 +6,6 @@ part of 'test_creator_getters.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -126,8 +125,6 @@ class $PageObjectHasGettersAndActions extends PageObjectHasGettersAndActions
 
 mixin $$PageObjectHasGettersAndActions on PageObjectHasGettersAndActions {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageObjectHasGettersAndActions() {
     return {
@@ -182,8 +179,6 @@ mixin $$PageObjectHasGettersAndActions on PageObjectHasGettersAndActions {
     return {closestIndex: closestValue};
   }
 
-  String get testContext;
-  String get name;
   PageLoaderElement get input {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod(
@@ -198,7 +193,6 @@ mixin $$PageObjectHasGettersAndActions on PageObjectHasGettersAndActions {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -327,8 +321,6 @@ class $PageObjectHasGettersThatUseDifferentReturnTypes
 mixin $$PageObjectHasGettersThatUseDifferentReturnTypes
     on PageObjectHasGettersThatUseDifferentReturnTypes {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String>
       testCreatorGettersInPageObjectHasGettersThatUseDifferentReturnTypes() {
@@ -401,9 +393,6 @@ mixin $$PageObjectHasGettersThatUseDifferentReturnTypes
     return {closestIndex: closestValue};
   }
 
-  String get testContext;
-  bool get exists;
-  int get size;
   PageLoaderElement get input {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod(
@@ -434,7 +423,6 @@ mixin $$PageObjectHasGettersThatUseDifferentReturnTypes
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -527,8 +515,6 @@ class $PageObjectHasNoGetters extends PageObjectHasNoGetters
 
 mixin $$PageObjectHasNoGetters on PageObjectHasNoGetters {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageObjectHasNoGetters() {
     return {};
@@ -587,7 +573,6 @@ mixin $$PageObjectHasNoGetters on PageObjectHasNoGetters {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -701,8 +686,6 @@ class $PageObjectWithMixin extends PageObjectWithMixin
 
 mixin $$PageObjectWithMixin on PageObjectWithMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageObjectWithMixin() {
     return {
@@ -750,8 +733,6 @@ mixin $$PageObjectWithMixin on PageObjectWithMixin {
     return {closestIndex: closestValue};
   }
 
-  String get testContext;
-  String get name;
   PageLoaderElement get input {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageObjectWithMixin', 'input');
@@ -765,15 +746,12 @@ mixin $$PageObjectWithMixin on PageObjectWithMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$PageObjectMixin on PageObjectMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageObjectMixin() {
     return {
@@ -820,8 +798,6 @@ mixin $$PageObjectMixin on PageObjectMixin {
     return {closestIndex: closestValue};
   }
 
-  String get tabContext;
-  String get tabName;
   PageLoaderElement get tab {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageObjectMixin', 'tab');
@@ -835,7 +811,6 @@ mixin $$PageObjectMixin on PageObjectMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -943,8 +918,6 @@ class $PageObjectWithOverridingMixins extends PageObjectWithOverridingMixins
 
 mixin $$PageObjectWithOverridingMixins on PageObjectWithOverridingMixins {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageObjectWithOverridingMixins() {
     return {
@@ -974,6 +947,4 @@ mixin $$PageObjectWithOverridingMixins on PageObjectWithOverridingMixins {
     String Function(List<String>) closestValue;
     return {closestIndex: closestValue};
   }
-
-  String get tabContext;
 }

--- a/test/src/test_creator_invoke_method.g.dart
+++ b/test/src/test_creator_invoke_method.g.dart
@@ -6,7 +6,6 @@ part of 'test_creator_invoke_method.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -128,8 +127,6 @@ class $PageObjectHasGettersAndMethods extends PageObjectHasGettersAndMethods
 
 mixin $$PageObjectHasGettersAndMethods on PageObjectHasGettersAndMethods {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageObjectHasGettersAndMethods() {
     return {
@@ -204,7 +201,6 @@ mixin $$PageObjectHasGettersAndMethods on PageObjectHasGettersAndMethods {
     return {closestIndex: closestValue};
   }
 
-  String get getter;
   PageLoaderElement get po {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod('PageObjectHasGettersAndMethods', 'po');
@@ -233,7 +229,6 @@ mixin $$PageObjectHasGettersAndMethods on PageObjectHasGettersAndMethods {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -392,8 +387,6 @@ class $PageObjectHasGettersAndMethodsWithMixin
 mixin $$PageObjectHasGettersAndMethodsWithMixin
     on PageObjectHasGettersAndMethodsWithMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String>
       testCreatorGettersInPageObjectHasGettersAndMethodsWithMixin() {
@@ -470,7 +463,6 @@ mixin $$PageObjectHasGettersAndMethodsWithMixin
     return {closestIndex: closestValue};
   }
 
-  String get getter;
   PageLoaderElement get po {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod(
@@ -501,7 +493,6 @@ mixin $$PageObjectHasGettersAndMethodsWithMixin
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -509,8 +500,6 @@ mixin $$PageObjectHasGettersAndMethodsWithMixin
 mixin $$PageObjectMixinHasGettersAndMethods
     on PageObjectMixinHasGettersAndMethods {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String>
       testCreatorGettersInPageObjectMixinHasGettersAndMethods() {
@@ -589,7 +578,6 @@ mixin $$PageObjectMixinHasGettersAndMethods
     return {closestIndex: closestValue};
   }
 
-  String get getter;
   PageLoaderElement get po2 {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod(
@@ -620,15 +608,12 @@ mixin $$PageObjectMixinHasGettersAndMethods
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$RightMostPageObjectMixin on RightMostPageObjectMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInRightMostPageObjectMixin() {
     return {};

--- a/test/src/test_creator_methods.g.dart
+++ b/test/src/test_creator_methods.g.dart
@@ -6,7 +6,6 @@ part of 'test_creator_methods.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -155,8 +154,6 @@ class $PageObjectHasPropertiesAndMethods
 
 mixin $$PageObjectHasPropertiesAndMethods on PageObjectHasPropertiesAndMethods {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageObjectHasPropertiesAndMethods() {
     return {
@@ -218,8 +215,6 @@ mixin $$PageObjectHasPropertiesAndMethods on PageObjectHasPropertiesAndMethods {
     return {closestIndex: closestValue};
   }
 
-  String get testContext;
-  String get name;
   PageLoaderElement get input {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod(
@@ -235,7 +230,6 @@ mixin $$PageObjectHasPropertiesAndMethods on PageObjectHasPropertiesAndMethods {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -403,8 +397,6 @@ class $PageObjectHasMethodsWithDifferentParameters
 mixin $$PageObjectHasMethodsWithDifferentParameters
     on PageObjectHasMethodsWithDifferentParameters {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String>
       testCreatorGettersInPageObjectHasMethodsWithDifferentParameters() {
@@ -475,7 +467,6 @@ mixin $$PageObjectHasMethodsWithDifferentParameters
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -557,8 +548,6 @@ class $PageObjectHasNoMethods extends PageObjectHasNoMethods
 
 mixin $$PageObjectHasNoMethods on PageObjectHasNoMethods {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageObjectHasNoMethods() {
     return {};
@@ -610,7 +599,6 @@ mixin $$PageObjectHasNoMethods on PageObjectHasNoMethods {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -713,8 +701,6 @@ class $PageObjectWithMixin extends PageObjectWithMixin
 
 mixin $$PageObjectWithMixin on PageObjectWithMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageObjectWithMixin() {
     return {};
@@ -774,15 +760,12 @@ mixin $$PageObjectWithMixin on PageObjectWithMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
 
 mixin $$PageObjectMixin on PageObjectMixin {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageObjectMixin() {
     return {};
@@ -838,7 +821,6 @@ mixin $$PageObjectMixin on PageObjectMixin {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -968,8 +950,6 @@ class $PageObjectWithOverridingMixins extends PageObjectWithOverridingMixins
 
 mixin $$PageObjectWithOverridingMixins on PageObjectWithOverridingMixins {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageObjectWithOverridingMixins() {
     return {};

--- a/test/src/typing.dart
+++ b/test/src/typing.dart
@@ -66,8 +66,12 @@ void runTests(GetNewContext contextGenerator, {isHtmlTest = false}) {
       test('enter all sent', () async {
         kb.typeSpecialKey(PageLoaderSpecialKey.enter);
         await listener.typeSequence(kb);
-        expect(listener.visibleText,
-            equals('Listening: enter keydown; enter keypress; enter keyup;'));
+        final expected = isHtmlTest
+            ? 'Listening: enter keydown; (Enter key value); '
+                'enter keypress; '
+                'enter keyup; (Enter key value);'
+            : 'Listening: enter keydown; enter keypress; enter keyup;';
+        expect(listener.visibleText, equals(expected));
       });
     });
   });
@@ -190,7 +194,7 @@ void runTests(GetNewContext contextGenerator, {isHtmlTest = false}) {
 
     test('enter only keydown and keypress sent', () async {
       final result = isHtmlTest
-          ? 'Listening: enter keydown; enter keypress;'
+          ? 'Listening: enter keydown; (Enter key value); enter keypress;'
           : 'Listening: enter keydown; enter keypress; enter keyup;';
       kb.typeSpecialKey(PageLoaderSpecialKey.enter, keyUp: false);
       await listener.typeSequence(kb);
@@ -199,7 +203,7 @@ void runTests(GetNewContext contextGenerator, {isHtmlTest = false}) {
 
     test('enter only keyup sent', () async {
       final result = isHtmlTest
-          ? 'Listening: enter keyup;'
+          ? 'Listening: enter keyup; (Enter key value);'
           : 'Listening: enter keydown; enter keypress; enter keyup;';
       kb.typeSpecialKey(PageLoaderSpecialKey.enter, keyDown: false);
       await listener.typeSequence(kb);

--- a/test/src/typing.g.dart
+++ b/test/src/typing.g.dart
@@ -6,7 +6,6 @@ part of 'typing.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -88,8 +87,6 @@ class $PageForTextAreaTypingText extends PageForTextAreaTypingText
 
 mixin $$PageForTextAreaTypingText on PageForTextAreaTypingText {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForTextAreaTypingText() {
     return {};
@@ -141,7 +138,6 @@ mixin $$PageForTextAreaTypingText on PageForTextAreaTypingText {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -220,8 +216,6 @@ class $PageForTypingTests extends PageForTypingTests with $$PageForTypingTests {
 
 mixin $$PageForTypingTests on PageForTypingTests {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForTypingTests() {
     return {};
@@ -273,7 +267,6 @@ mixin $$PageForTypingTests on PageForTypingTests {
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -384,8 +377,6 @@ class $PageForTypingTestsWithFocusAndBlur
 mixin $$PageForTypingTestsWithFocusAndBlur
     on PageForTypingTestsWithFocusAndBlur {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInPageForTypingTestsWithFocusAndBlur() {
     return {
@@ -453,8 +444,6 @@ mixin $$PageForTypingTestsWithFocusAndBlur
     return {closestIndex: closestValue};
   }
 
-  int get focusCount;
-  int get blurCount;
   PageLoaderElement get text {
     for (final __listener in $__root__.listeners) {
       __listener.startPageObjectMethod(
@@ -501,7 +490,6 @@ mixin $$PageForTypingTestsWithFocusAndBlur
   }
 }
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -580,8 +568,6 @@ class $KeyboardListenerPO extends KeyboardListenerPO with $$KeyboardListenerPO {
 
 mixin $$KeyboardListenerPO on KeyboardListenerPO {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInKeyboardListenerPO() {
     return {};

--- a/test/src/webdriver_only.g.dart
+++ b/test/src/webdriver_only.g.dart
@@ -6,7 +6,6 @@ part of 'webdriver_only.dart';
 // PageObjectGenerator
 // **************************************************************************
 
-// ignore_for_file: private_collision_in_mixin_application
 // ignore_for_file: unused_field, non_constant_identifier_names
 // ignore_for_file: overridden_fields, annotate_overrides
 // ignore_for_file: prefer_final_locals, deprecated_member_use_from_same_package
@@ -85,8 +84,6 @@ class $WebDriverOnly extends WebDriverOnly with $$WebDriverOnly {
 
 mixin $$WebDriverOnly on WebDriverOnly {
   PageLoaderElement $__root__;
-  PageLoaderMouse __mouse__;
-  PageLoaderPointer __pointer__;
   PageLoaderElement get $root => $__root__;
   Map<String, String> testCreatorGettersInWebDriverOnly() {
     return {};


### PR DESCRIPTION
Pull request to bump PageLoader right before null-safety migration. v3.3.2 will be the last version supporting non-null-safe dart (SDK <2.12.0). This version bump was delayed since internally there were versioning, codegen, and null-safety migration concerns; with these resolved we can safely bump to 3.3.2.

Next version (4.0.0) will be null-safe and will bump remaining dependencies respectively. If there are no syncing issues, this is expected to land by end of May 2021 / early June.

## 3.3.2

- Bump dependencies up until but not included null safety versions.
- Stop using deprecated API calls from `analyzer`.
- Remove violations of `private_collision_in_mixin_application`.
- Fix generated code to be compatible with `implicit_casts: false`.
- Use `<int>` type parameter with `Point`.
- Use `Iterator` in HTML/Webdriver iterators to prevent explicit `null` returns.
- Syntactical changes to make null safety migration easier.
- `HtmlPageLoaderElement` sends `key` property value on keyboard usage.
- Add support for `shadowDomChildren`. `shadowDom` is still not supported since it does not return a singular `Element`. However, users may still need to access its children elements.
- Make errors from `@CheckTag`/`@CheckTags` more descriptive.
- Remove usages of `dart:async` imports; they're part of `dart:core` now.
- Improve error message on `isFocused` test matcher.
- Respect `clickOption` in `HtmlPageLoaderElement`'s `click()` method.
- Make `WebdriverPageLoaderElement`'s click more tolerant to changed views ports.
- Check whether a `WebdriverPageLoaderElement` is displayed or not on `visibleText` and `click`.

Resolves issues:

- #216 : Compatible with Angular6
- #215 : Fix InconsistentAnalysisException
- #210  : Analyzer 0.40 support